### PR TITLE
Implemented Glue ETL job script deployment using terraform

### DIFF
--- a/infra/glue/README.md
+++ b/infra/glue/README.md
@@ -1,6 +1,6 @@
 # Glue
 
-We use AWS Glue to drive all structure/semi-structure into *Staging* layer of our warehouse. This technique is called data preloading.
+We use AWS Glue to drive all structure/semi-structure data from sources into warehouse staging layer.
 
 ## Local Development
 
@@ -12,7 +12,7 @@ uv pip install -r requirements-dev.txt
 
 ```
 aws sso login
-assume -r umccr-dev-admin
+assume umccr-dev-admin
 ```
 
 Consider this public JSON line dataset.
@@ -36,3 +36,71 @@ pytest
 ```
 
 This gives local spark dev & debug routine before deploying the job script to remote.
+
+
+## Deploy
+
+```
+cd deploy
+```
+
+```
+terraform workspace list
+  default
+* prod
+```
+
+```
+export AWS_PROFILE=umccr-prod-admin && terraform workspace select prod && terraform plan
+terraform apply
+```
+
+## Run
+
+```
+export AWS_PROFILE=umccr-prod-admin
+```
+
+```
+aws glue list-jobs
+{
+    "JobNames": [
+        "orcahouse-spreadsheet-library-tracking-metadata-job"
+    ]
+}
+```
+
+```
+aws glue start-job-run --job-name orcahouse-spreadsheet-library-tracking-metadata-job
+{
+    "JobRunId": "jr_ec42af440ad35b948b2af17b88459a31a2248275f464c6a353638349f9d178d1"
+}
+```
+
+```
+aws glue get-job-run --job-name orcahouse-spreadsheet-library-tracking-metadata-job --run-id jr_ec42af440ad35b948b2af17b88459a31a2248275f464c6a353638349f9d178d1
+{
+    "JobRun": {
+        "Id": "jr_ec42af440ad35b948b2af17b88459a31a2248275f464c6a353638349f9d178d1",
+        "Attempt": 0,
+        "JobName": "orcahouse-spreadsheet-library-tracking-metadata-job",
+        "JobMode": "SCRIPT",
+        "JobRunQueuingEnabled": false,
+        "StartedOn": "2025-01-11T17:12:49.739000+11:00",
+        "LastModifiedOn": "2025-01-11T17:14:48.111000+11:00",
+        "CompletedOn": "2025-01-11T17:14:48.111000+11:00",
+        "JobRunState": "SUCCEEDED",
+        "PredecessorRuns": [],
+        "AllocatedCapacity": 1,
+        "ExecutionTime": 106,
+        "Timeout": 15,
+        "MaxCapacity": 1.0,
+        "WorkerType": "Standard",
+        "NumberOfWorkers": 1,
+        "LogGroupName": "/aws-glue/jobs",
+        "GlueVersion": "5.0"
+    }
+}
+```
+
+Or, use UI AWS Glue Console.

--- a/infra/glue/deploy/.terraform.lock.hcl
+++ b/infra/glue/deploy/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.78.0"
+  constraints = "5.78.0"
+  hashes = [
+    "h1:o7jz+dFixEcwjfdubken5ldmDJm1tkvM2adPtNDei3g=",
+    "zh:0ae7d41b96441d0cf7ce2e1337657bdb2e1e5c9f1c2227b0642e1dcec2f9dfba",
+    "zh:21f8f1edf477681ea3b095c02cad6b8e85262e45015de58e84e0c7b2bfe9a1f6",
+    "zh:2bdc335e341bf98445255549ae93d66cfb9bca706e62b949da98fe467c182cad",
+    "zh:2fe4096e260367a225a9faf4a424d62b87e5498f12cb43bdb6f4e713d11b82c3",
+    "zh:3c63bb7a7925d65118d17461f4691a22dbb55ea39a7404e4d71f6ccca8765f8b",
+    "zh:6609a28a1c638a1901d8007b5386868ccfd313b4df2e98b35d9fdef436974e3b",
+    "zh:7ae3aef43bc4b365824cca4659cf92459d766800656e354bdbf83feabab835e8",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:c314efe454adc6ca483261c6906e64315aeb9db0c0332818714e9b81e07df0f0",
+    "zh:cd3e30396b554bbc1d260252db8a0f344065d619038fe60ea870689cd32c6aa9",
+    "zh:d1ba48fd9d8a1cb1daa927fb9e8bb708b857f2792d796e110460c6fdcd896a47",
+    "zh:d31c8abe75cb9cdc1c59ad9d356a1c3ae1ba8cd29ac15eb7e01b6cd01221ab04",
+    "zh:dc27c5c2116b4d9b404753f73bccaa635bce21f3bfb4bb7bc8e63225c36c98fe",
+    "zh:de491f0d05408378413187475c815d8cb2ac6bfa63d0b42a30ad5ee492e51c07",
+    "zh:eb44b45a40f80a309dd5b0eb7d7fcb2cbfe588fe2f18b173ef5851346898a662",
+  ]
+}

--- a/infra/glue/deploy/iam.tf
+++ b/infra/glue/deploy/iam.tf
@@ -1,0 +1,59 @@
+data "aws_iam_policy_document" "glue_assume_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["glue.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "glue_s3_policy" {
+  statement {
+    actions = sort([
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:ListBucket",
+    ])
+    resources = sort([
+      data.aws_s3_bucket.glue_script_bucket.arn,
+      "${data.aws_s3_bucket.glue_script_bucket.arn}/*"
+    ])
+  }
+
+  statement {
+    actions = sort([
+      "secretsmanager:GetSecretValue",
+    ])
+    resources = sort([
+      data.aws_secretsmanager_secret.orcavault_tsa.arn
+    ])
+  }
+
+  statement {
+    actions = sort([
+      "ssm:GetParametersByPath",
+      "ssm:GetParameters",
+      "ssm:GetParameter",
+    ])
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role" "glue_role" {
+  name               = "${local.stack_name}-glue-job-role"
+  assume_role_policy = data.aws_iam_policy_document.glue_assume_policy.json
+}
+
+resource "aws_iam_role_policy" "glue_s3_policy" {
+  name   = "${local.stack_name}-glue-s3-policy"
+  role   = aws_iam_role.glue_role.id
+  policy = data.aws_iam_policy_document.glue_s3_policy.json
+}
+
+# Attach AWSGlueServiceRole policy for general GlueOps
+# https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSGlueServiceRole.html
+resource "aws_iam_role_policy_attachment" "ssm_instance_policy" {
+  role       = aws_iam_role.glue_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
+}

--- a/infra/glue/deploy/main.tf
+++ b/infra/glue/deploy/main.tf
@@ -1,0 +1,83 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  backend "s3" {
+    bucket         = "umccr-terraform-states"
+    key            = "orcahouse-glue/terraform.tfstate"
+    region         = "ap-southeast-2"
+    dynamodb_table = "terraform-state-lock"
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.78.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "ap-southeast-2"
+  default_tags {
+    tags = {
+      "umccr-org:Product" = "OrcaHouse"
+      "umccr-org:Creator" = "Terraform"
+      "umccr-org:Service" = "OrcaHouse"
+      "umccr-org:Source"  = "https://github.com/umccr/orcahouse"
+    }
+  }
+}
+
+locals {
+  stack_name                 = "orcahouse"
+  sorted_private_subnets     = sort(data.aws_subnets.private_subnets_ids.ids)
+  selected_private_subnet_id = local.sorted_private_subnets[0]
+}
+
+data "aws_vpc" "main_vpc" {
+  # Using tags filter on networking stack to get main-vpc
+  tags = {
+    Name        = "main-vpc"
+    Stack       = "networking"
+    Environment = terraform.workspace
+  }
+}
+
+data "aws_subnets" "private_subnets_ids" {
+  filter {
+    name = "vpc-id"
+    values = [data.aws_vpc.main_vpc.id]
+  }
+
+  tags = {
+    Tier = "private"
+  }
+}
+
+data "aws_subnet" "selected" {
+  id = local.selected_private_subnet_id
+}
+
+data "aws_rds_cluster" "orcahouse_db" {
+  cluster_identifier = "orcahouse-db"
+}
+
+variable "orcabus_compute_sg_id" {
+  default = {
+    dev  = ""
+    prod = "sg-02e363a39220c955f"
+    stg  = ""
+  }
+}
+
+variable "staging_bucket" {
+  default = {
+    dev  = ""
+    prod = "orcahouse-staging-data-472057503814"
+    stg  = ""
+  }
+}
+
+data "aws_s3_bucket" "glue_script_bucket" {
+  bucket = var.staging_bucket[terraform.workspace]
+}

--- a/infra/glue/deploy/orcavault_tsa.tf
+++ b/infra/glue/deploy/orcavault_tsa.tf
@@ -1,0 +1,86 @@
+locals {
+  database_name = "orcavault"
+}
+
+data "aws_ssm_parameter" "orcavault_tsa_username" {
+  name = "/${local.stack_name}/${local.database_name}/tsa_username"
+}
+
+data "aws_secretsmanager_secret" "orcavault_tsa" {
+  name = "${local.stack_name}/${local.database_name}/${data.aws_ssm_parameter.orcavault_tsa_username.value}"
+}
+
+# ---
+
+resource "aws_glue_connection" "orcavault_tsa" {
+  name = "${local.stack_name}-${local.database_name}-${data.aws_ssm_parameter.orcavault_tsa_username.value}"
+
+  # https://docs.aws.amazon.com/glue/latest/dg/connection-properties.html
+  connection_properties = {
+    JDBC_CONNECTION_URL = "jdbc:postgresql://${data.aws_rds_cluster.orcahouse_db.endpoint}:5432/${local.database_name}"
+    SECRET_ID           = data.aws_secretsmanager_secret.orcavault_tsa.name
+  }
+
+  physical_connection_requirements {
+    security_group_id_list = sort([var.orcabus_compute_sg_id.prod])
+    subnet_id              = data.aws_subnet.selected.id
+    availability_zone      = data.aws_subnet.selected.availability_zone
+  }
+}
+
+# ---
+
+resource "aws_s3_object" "requirements_txt" {
+  bucket = data.aws_s3_bucket.glue_script_bucket.bucket
+  key    = "glue/requirements.txt"
+  source = "../requirements.txt"
+  etag   = filemd5("../requirements.txt")
+}
+
+# ---
+
+resource "aws_s3_object" "spreadsheet_library_tracking_metadata" {
+  bucket = data.aws_s3_bucket.glue_script_bucket.bucket
+  key    = "glue/spreadsheet_library_tracking_metadata/spreadsheet_library_tracking_metadata.py"
+  source = "../workspace/spreadsheet_library_tracking_metadata/spreadsheet_library_tracking_metadata.py"
+  etag   = filemd5("../workspace/spreadsheet_library_tracking_metadata/spreadsheet_library_tracking_metadata.py")
+}
+
+resource "aws_glue_job" "spreadsheet_library_tracking_metadata" {
+  name              = "${local.stack_name}-spreadsheet-library-tracking-metadata-job"
+  role_arn          = aws_iam_role.glue_role.arn
+  glue_version      = "5.0"
+  worker_type       = "Standard"
+  number_of_workers = 1
+  timeout           = 15
+
+  connections = sort([
+    aws_glue_connection.orcavault_tsa.name
+  ])
+
+  command {
+    name            = "glueetl"
+    script_location = "s3://${data.aws_s3_bucket.glue_script_bucket.bucket}/${aws_s3_object.spreadsheet_library_tracking_metadata.key}"
+    python_version  = "3"
+  }
+
+  default_arguments = {
+    "--job-language" = "python"
+    "--python-modules-installer-option" = "-r"
+    "--additional-python-modules" = "s3://${data.aws_s3_bucket.glue_script_bucket.bucket}/${aws_s3_object.requirements_txt.key}"
+  }
+}
+
+resource "aws_glue_trigger" "spreadsheet_library_tracking_metadata" {
+  name              = "${aws_glue_job.spreadsheet_library_tracking_metadata.name}-scheduled-trigger"
+  type              = "SCHEDULED"
+  schedule          = "cron(10 13 * * ? *)"  # Cron expression to run daily at 13:10 PM UTC = AEST/AEDT 00:10 AM
+  description       = "Daily trigger for ${aws_glue_job.spreadsheet_library_tracking_metadata.name}"
+  start_on_creation = true
+
+  actions {
+    job_name = aws_glue_job.spreadsheet_library_tracking_metadata.name
+  }
+
+  depends_on = [aws_glue_job.spreadsheet_library_tracking_metadata]
+}

--- a/infra/glue/requirements.txt
+++ b/infra/glue/requirements.txt
@@ -1,5 +1,5 @@
 libumccr==0.4.1
 google-auth==2.37.0
-requests==2.23.0
+requests==2.32.3
 polars==1.19.0
 fastexcel==0.12.0


### PR DESCRIPTION
* This leverages latest Glue version 5.0 to provision additional
  Python dependency packages install via requirements.txt.
* Added Glue Connection setup for JDBC to OrcaVault database `tsa`
  schema as the data staging area target.
* Added scheduled Glue Job Trigger; past 10 minutes midnight for
  daily data loading.
* The target schema is `tsa` (Transient Staging Area). Hence, it is
  truncate and reload strategy for tsa purpose. History tracking will
  be implemented by further warehouse layers in psa and vault schema.
