### PR TITLE
Implemented OrcaVault tsa schema spreadsheet Google LIMS

### DIFF
--- a/dev/src/load.sh
+++ b/dev/src/load.sh
@@ -17,4 +17,5 @@ PGPASSWORD=dev psql -h 0.0.0.0 -d orcavault -U dev <<EOF
 \copy ods.metadata_manager_contact from '/data/orcavault_ods_metadata_manager_contact.csv' with (format csv, header true, delimiter ',');
 \copy ods.metadata_manager_projectcontactlink from '/data/orcavault_ods_metadata_manager_projectcontactlink.csv' with (format csv, header true, delimiter ',');
 \copy tsa.spreadsheet_library_tracking_metadata from '/data/orcavault_tsa_spreadsheet_library_tracking_metadata.csv' with (format csv, header true, delimiter ',');
+\copy tsa.spreadsheet_google_lims from '/data/orcavault_tsa_spreadsheet_google_lims.csv' with (format csv, header true, delimiter ',');
 EOF

--- a/dev/src/next.sh
+++ b/dev/src/next.sh
@@ -4,4 +4,5 @@ PGPASSWORD=dev psql -h 0.0.0.0 -d orcavault -U dev -c 'SELECT tsa.truncate_table
 
 PGPASSWORD=dev psql -h 0.0.0.0 -d orcavault -U dev <<EOF
 \copy tsa.spreadsheet_library_tracking_metadata from '/data/orcavault_tsa_spreadsheet_library_tracking_metadata.next.csv' with (format csv, header true, delimiter ',');
+\copy tsa.spreadsheet_google_lims from '/data/orcavault_tsa_spreadsheet_google_lims.next.csv' with (format csv, header true, delimiter ',');
 EOF

--- a/dev/src/tsa.sql
+++ b/dev/src/tsa.sql
@@ -57,3 +57,37 @@ CREATE TABLE IF NOT EXISTS orcavault.tsa.spreadsheet_library_tracking_metadata
     study                 varchar,
     sheet_name            varchar
 );
+
+CREATE TABLE IF NOT EXISTS orcavault.tsa.spreadsheet_google_lims
+(
+    illumina_id         varchar,
+    run                 varchar,
+    timestamp           varchar,
+    subject_id          varchar,
+    sample_id           varchar,
+    library_id          varchar,
+    external_subject_id varchar,
+    external_sample_id  varchar,
+    external_library_id varchar,
+    sample_name         varchar,
+    project_owner       varchar,
+    project_name        varchar,
+    project_custodian   varchar,
+    type                varchar,
+    assay               varchar,
+    override_cycles     varchar,
+    phenotype           varchar,
+    source              varchar,
+    quality             varchar,
+    topup               varchar,
+    secondary_analysis  varchar,
+    workflow            varchar,
+    tags                varchar,
+    fastq               varchar,
+    number_fastqs       varchar,
+    results             varchar,
+    trello              varchar,
+    notes               varchar,
+    todo                varchar,
+    sheet_name          varchar
+);

--- a/orcavault/models/tsa/sources.yml
+++ b/orcavault/models/tsa/sources.yml
@@ -6,3 +6,4 @@ sources:
     schema: tsa
     tables:
       - name: spreadsheet_library_tracking_metadata
+      - name: spreadsheet_google_lims


### PR DESCRIPTION
* Story: Let Glue the Google LIMS! (continue)
  Now that we have `tsa.spreadsheet_google_lims` in staging data area
  by Glue ETL job in #19, we can source this data table with dbt to further feed into
  the downstream warehouse layers in psa and vault schema.
* Technical steps are now mainly inherited by the framework implemented in PR #15.
  Hence, this step becomes pretty straight forward task and template code.
