### PR TITLE
Implemented OrcaVault psa schema spreadsheet Google LIMS

### DIFF
--- a/dev/src/psa.sql
+++ b/dev/src/psa.sql
@@ -36,3 +36,39 @@ CREATE TABLE IF NOT EXISTS orcavault.psa.spreadsheet_library_tracking_metadata
     load_datetime         timestamptz,
     record_source         varchar(255)
 );
+
+CREATE TABLE IF NOT EXISTS orcavault.psa.spreadsheet_google_lims
+(
+    illumina_id         varchar,
+    run                 integer,
+    timestamp           date,
+    subject_id          varchar,
+    sample_id           varchar,
+    library_id          varchar,
+    external_subject_id varchar,
+    external_sample_id  varchar,
+    external_library_id varchar,
+    sample_name         varchar,
+    project_owner       varchar,
+    project_name        varchar,
+    project_custodian   varchar,
+    type                varchar,
+    assay               varchar,
+    override_cycles     varchar,
+    phenotype           varchar,
+    source              varchar,
+    quality             varchar,
+    topup               varchar,
+    secondary_analysis  varchar,
+    workflow            varchar,
+    tags                varchar,
+    fastq               varchar,
+    number_fastqs       varchar,
+    results             varchar,
+    trello              varchar,
+    notes               varchar,
+    todo                varchar,
+    sheet_name          varchar,
+    load_datetime       timestamptz,
+    record_source       varchar(255)
+);

--- a/orcavault/models/psa/schema.yml
+++ b/orcavault/models/psa/schema.yml
@@ -58,3 +58,70 @@ models:
         data_type: timestamptz
       - name: record_source
         data_type: varchar(255)
+
+  - name: spreadsheet_google_lims
+    columns:
+      - name: illumina_id
+        data_type: varchar
+      - name: run
+        data_type: varchar
+      - name: timestamp
+        data_type: varchar
+      - name: subject_id
+        data_type: varchar
+      - name: sample_id
+        data_type: varchar
+      - name: library_id
+        data_type: varchar
+      - name: external_subject_id
+        data_type: varchar
+      - name: external_sample_id
+        data_type: varchar
+      - name: external_library_id
+        data_type: varchar
+      - name: sample_name
+        data_type: varchar
+      - name: project_owner
+        data_type: varchar
+      - name: project_name
+        data_type: varchar
+      - name: project_custodian
+        data_type: varchar
+      - name: type
+        data_type: varchar
+      - name: assay
+        data_type: varchar
+      - name: override_cycles
+        data_type: varchar
+      - name: phenotype
+        data_type: varchar
+      - name: source
+        data_type: varchar
+      - name: quality
+        data_type: varchar
+      - name: topup
+        data_type: varchar
+      - name: secondary_analysis
+        data_type: varchar
+      - name: workflow
+        data_type: varchar
+      - name: tags
+        data_type: varchar
+      - name: fastq
+        data_type: varchar
+      - name: number_fastqs
+        data_type: varchar
+      - name: results
+        data_type: varchar
+      - name: trello
+        data_type: varchar
+      - name: notes
+        data_type: varchar
+      - name: todo
+        data_type: varchar
+      - name: sheet_name
+        data_type: varchar
+      - name: load_datetime
+        data_type: timestamptz
+      - name: record_source
+        data_type: varchar(255)

--- a/orcavault/models/psa/spreadsheet_google_lims.sql
+++ b/orcavault/models/psa/spreadsheet_google_lims.sql
@@ -1,0 +1,146 @@
+{{
+    config(
+        materialized='incremental'
+    )
+}}
+
+with cutoff as (
+
+    select coalesce(max(load_datetime), '1900-01-01') as ldts from {{ this }}
+
+),
+
+source as (
+
+    select
+        *
+    from
+        {{ source('tsa', 'spreadsheet_google_lims') }}
+
+    {% if is_incremental() %}
+
+    where cast("timestamp" as timestamptz) + time '11:00' > ( select ldts from cutoff )
+
+    {% endif %}
+
+),
+
+cleaned as (
+
+    select
+        trim(regexp_replace(illumina_id, E'[\\n\\r]+', '', 'g')) as illumina_id,
+        trim(regexp_replace(run, E'[\\n\\r]+', '', 'g')) as run,
+        trim(regexp_replace("timestamp", E'[\\n\\r]+', '', 'g')) as "timestamp",
+        trim(regexp_replace(subject_id, E'[\\n\\r]+', '', 'g')) as subject_id,
+        trim(regexp_replace(sample_id, E'[\\n\\r]+', '', 'g')) as sample_id,
+        trim(regexp_replace(library_id, E'[\\n\\r]+', '', 'g')) as library_id,
+        trim(regexp_replace(external_subject_id, E'[\\n\\r]+', '', 'g')) as external_subject_id,
+        trim(regexp_replace(external_sample_id, E'[\\n\\r]+', '', 'g')) as external_sample_id,
+        trim(regexp_replace(external_library_id, E'[\\n\\r]+', '', 'g')) as external_library_id,
+        trim(regexp_replace(sample_name, E'[\\n\\r]+', '', 'g')) as sample_name,
+        trim(regexp_replace(project_owner, E'[\\n\\r]+', '', 'g')) as project_owner,
+        trim(regexp_replace(project_name, E'[\\n\\r]+', '', 'g')) as project_name,
+        trim(regexp_replace(project_custodian, E'[\\n\\r]+', '', 'g')) as project_custodian,
+        trim(regexp_replace(type, E'[\\n\\r]+', '', 'g')) as type,
+        trim(regexp_replace(assay, E'[\\n\\r]+', '', 'g')) as assay,
+        trim(regexp_replace(override_cycles, E'[\\n\\r]+', '', 'g')) as override_cycles,
+        trim(regexp_replace(phenotype, E'[\\n\\r]+', '', 'g')) as phenotype,
+        trim(regexp_replace(source, E'[\\n\\r]+', '', 'g')) as source,
+        trim(regexp_replace(quality, E'[\\n\\r]+', '', 'g')) as quality,
+        trim(regexp_replace(topup, E'[\\n\\r]+', '', 'g')) as topup,
+        trim(regexp_replace(secondary_analysis, E'[\\n\\r]+', '', 'g')) as secondary_analysis,
+        trim(regexp_replace(workflow, E'[\\n\\r]+', '', 'g')) as workflow,
+        trim(regexp_replace(tags, E'[\\n\\r]+', '', 'g')) as tags,
+        trim(regexp_replace(fastq, E'[\\n\\r]+', '', 'g')) as fastq,
+        trim(regexp_replace(number_fastqs, E'[\\n\\r]+', '', 'g')) as number_fastqs,
+        trim(regexp_replace(results, E'[\\n\\r]+', '', 'g')) as results,
+        trim(regexp_replace(trello, E'[\\n\\r]+', '', 'g')) as trello,
+        trim(regexp_replace(notes, E'[\\n\\r]+', '', 'g')) as notes,
+        trim(regexp_replace(todo, E'[\\n\\r]+', '', 'g')) as todo,
+        trim(regexp_replace(sheet_name, E'[\\n\\r]+', '', 'g')) as sheet_name
+    from
+        source
+    where
+        coalesce
+        (
+            nullif(illumina_id, ''),
+            nullif(run, ''),
+            nullif("timestamp", ''),
+            nullif(subject_id, ''),
+            nullif(sample_id, ''),
+            nullif(library_id, ''),
+            nullif(external_subject_id, ''),
+            nullif(external_sample_id, ''),
+            nullif(external_library_id, ''),
+            nullif(sample_name, ''),
+            nullif(project_owner, ''),
+            nullif(project_name, ''),
+            nullif(project_custodian, ''),
+            nullif(type, ''),
+            nullif(assay, ''),
+            nullif(override_cycles, ''),
+            nullif(phenotype, ''),
+            nullif(source, ''),
+            nullif(quality, ''),
+            nullif(topup, ''),
+            nullif(secondary_analysis, ''),
+            nullif(workflow, ''),
+            nullif(tags, ''),
+            nullif(fastq, ''),
+            nullif(number_fastqs, ''),
+            nullif(results, ''),
+            nullif(trello, ''),
+            nullif(notes, ''),
+            nullif(todo, ''),
+            nullif(sheet_name, '')
+        ) is not null
+
+),
+
+transformed as (
+
+    select
+        illumina_id,
+        cast(run as integer),
+        cast("timestamp" as date) as "timestamp",
+        subject_id,
+        sample_id,
+        library_id,
+        external_subject_id,
+        external_sample_id,
+        external_library_id,
+        sample_name,
+        project_owner,
+        project_name,
+        project_custodian,
+        type,
+        assay,
+        override_cycles,
+        phenotype,
+        source,
+        quality,
+        topup,
+        secondary_analysis,
+        workflow,
+        tags,
+        fastq,
+        number_fastqs,
+        results,
+        trello,
+        notes,
+        todo,
+        sheet_name,
+        cast("timestamp" as timestamptz) + time '11:00' as load_datetime,
+        (select 'Google_LIMS') as record_source
+    from
+        cleaned
+
+),
+
+final as (
+
+    select * from transformed
+
+)
+
+select * from final


### PR DESCRIPTION
* Story: Let Glue the Google LIMS! (continue)
  As discussed in #20, we now source `tsa.spreadsheet_google_lims` staging data
  table with dbt and feed into the downstream warehouse psa schema.
* Technical steps are now mainly inherited by the framework implemented in PR #17.
* With psa, Google LIMS is incrementally loaded with differential data records per
  daily scheduled run with dbt ELT job.
* Chiefly note; since Google LIMS preserved "timestamp" date column, we made use of it
  as (replay) historical time for the row record. Warehouse load datetime is derived
  from this timestamp column as initial cutover data extraction date.
