### PR TITLE
Updated OrcaVault hub models from PSA spreadsheet schema

### DIFF
--- a/orcavault/models/raw/hub_contact.sql
+++ b/orcavault/models/raw/hub_contact.sql
@@ -11,6 +11,10 @@ with source as (
     select project_owner as contact_id from {{ source('ods', 'data_portal_limsrow') }}
     union
     select contact_id from {{ source('ods', 'metadata_manager_contact') }}
+    union
+    select project_owner as contact_id from {{ ref('spreadsheet_library_tracking_metadata') }}
+    union
+    select project_owner as contact_id from {{ ref('spreadsheet_google_lims') }}
 
 ),
 

--- a/orcavault/models/raw/hub_experiment.sql
+++ b/orcavault/models/raw/hub_experiment.sql
@@ -7,6 +7,8 @@
 with source as (
 
     select experiment_id from {{ source('ods', 'data_portal_labmetadata') }}
+    union
+    select experiment_id from {{ ref('spreadsheet_library_tracking_metadata') }}
 
 ),
 

--- a/orcavault/models/raw/hub_external_sample.sql
+++ b/orcavault/models/raw/hub_external_sample.sql
@@ -11,6 +11,10 @@ with source as (
     select external_sample_id from {{ source('ods', 'data_portal_limsrow') }}
     union
     select external_sample_id from {{ source('ods', 'metadata_manager_sample') }}
+    union
+    select external_sample_id from {{ ref('spreadsheet_library_tracking_metadata') }}
+    union
+    select external_sample_id from {{ ref('spreadsheet_google_lims') }}
 
 ),
 

--- a/orcavault/models/raw/hub_external_subject.sql
+++ b/orcavault/models/raw/hub_external_subject.sql
@@ -11,6 +11,10 @@ with source as (
     select external_subject_id from {{ source('ods', 'data_portal_limsrow') }}
     union
     select subject_id as external_subject_id from {{ source('ods', 'metadata_manager_subject') }}
+    union
+    select external_subject_id from {{ ref('spreadsheet_library_tracking_metadata') }}
+    union
+    select external_subject_id from {{ ref('spreadsheet_google_lims') }}
 
 ),
 

--- a/orcavault/models/raw/hub_internal_subject.sql
+++ b/orcavault/models/raw/hub_internal_subject.sql
@@ -11,6 +11,10 @@ with source as (
     select subject_id as internal_subject_id from {{ source('ods', 'data_portal_limsrow') }}
     union
     select individual_id as internal_subject_id from {{ source('ods', 'metadata_manager_individual') }}
+    union
+    select subject_id as internal_subject_id from {{ ref('spreadsheet_library_tracking_metadata') }}
+    union
+    select subject_id as internal_subject_id from {{ ref('spreadsheet_google_lims') }}
 
 ),
 

--- a/orcavault/models/raw/hub_library.sql
+++ b/orcavault/models/raw/hub_library.sql
@@ -11,6 +11,10 @@ with source as (
     select library_id from {{ source('ods', 'data_portal_limsrow') }}
     union
     select library_id from {{ source('ods', 'metadata_manager_library') }}
+    union
+    select library_id from {{ ref('spreadsheet_library_tracking_metadata') }}
+    union
+    select library_id from {{ ref('spreadsheet_google_lims') }}
 
 ),
 

--- a/orcavault/models/raw/hub_project.sql
+++ b/orcavault/models/raw/hub_project.sql
@@ -11,6 +11,10 @@ with source as (
     select project_name as project_id from {{ source('ods', 'data_portal_limsrow') }}
     union
     select project_id from {{ source('ods', 'metadata_manager_project') }}
+    union
+    select project_name as project_id from {{ ref('spreadsheet_library_tracking_metadata') }}
+    union
+    select project_name as project_id from {{ ref('spreadsheet_google_lims') }}
 
 ),
 

--- a/orcavault/models/raw/hub_sample.sql
+++ b/orcavault/models/raw/hub_sample.sql
@@ -11,6 +11,10 @@ with source as (
     select sample_id from {{ source('ods', 'data_portal_limsrow') }}
     union
     select sample_id from {{ source('ods', 'metadata_manager_sample') }}
+    union
+    select sample_id from {{ ref('spreadsheet_library_tracking_metadata') }}
+    union
+    select sample_id from {{ ref('spreadsheet_google_lims') }}
 
 ),
 

--- a/orcavault/models/raw/hub_sequencing_run.sql
+++ b/orcavault/models/raw/hub_sequencing_run.sql
@@ -15,6 +15,8 @@ with source as (
     select instrument_run_id as sequencing_run_id from {{ source('ods', 'sequence_run_manager_sequence') }}
     union
     select illumina_id as sequencing_run_id from {{ source('ods', 'data_portal_limsrow') }}
+    union
+    select illumina_id as sequencing_run_id from {{ ref('spreadsheet_google_lims') }}
 
 ),
 


### PR DESCRIPTION
* This consolidates hub models from all possible record sources such as
  ODS (live Operational Data Store) as well as, historical spreadsheets that are
  now incubated in OrcaVault PSA (Persistent Staging Area) schema.
* See #21
* See #17
