### PR TITLE
Updated OrcaVault library-based link models from PSA spreadsheet schema

### DIFF
--- a/orcavault/models/raw/link_library_experiment.sql
+++ b/orcavault/models/raw/link_library_experiment.sql
@@ -1,6 +1,8 @@
 with source as (
 
     select library_id, experiment_id from {{ source('ods', 'data_portal_labmetadata') }}
+    union
+    select library_id, experiment_id from {{ ref('spreadsheet_library_tracking_metadata') }}
 
 ),
 

--- a/orcavault/models/raw/link_library_external_sample.sql
+++ b/orcavault/models/raw/link_library_external_sample.sql
@@ -6,6 +6,10 @@ with source as (
     union
     select lib.library_id as library_id, smp.external_sample_id as external_sample_id from {{ source('ods', 'metadata_manager_library') }} as lib
         join {{ source('ods', 'metadata_manager_sample') }} as smp on smp.orcabus_id = lib.sample_orcabus_id
+    union
+    select library_id, external_sample_id from {{ ref('spreadsheet_library_tracking_metadata') }}
+    union
+    select library_id, external_sample_id from {{ ref('spreadsheet_google_lims') }}
 
 ),
 

--- a/orcavault/models/raw/link_library_external_subject.sql
+++ b/orcavault/models/raw/link_library_external_subject.sql
@@ -6,6 +6,10 @@ with source as (
     union
     select lib.library_id as library_id, sbj.subject_id as external_subject_id from {{ source('ods', 'metadata_manager_library') }} as lib
         join {{ source('ods', 'metadata_manager_subject') }} as sbj on sbj.orcabus_id = lib.subject_orcabus_id
+    union
+    select library_id, external_subject_id from {{ ref('spreadsheet_library_tracking_metadata') }}
+    union
+    select library_id, external_subject_id from {{ ref('spreadsheet_google_lims') }}
 
 ),
 

--- a/orcavault/models/raw/link_library_internal_subject.sql
+++ b/orcavault/models/raw/link_library_internal_subject.sql
@@ -8,6 +8,10 @@ with source as (
         join {{ source('ods', 'metadata_manager_subject') }} as sbj on sbj.orcabus_id = lib.subject_orcabus_id
         join {{ source('ods', 'metadata_manager_subjectindividuallink') }} as lnk on lnk.subject_orcabus_id = sbj.orcabus_id
         join {{ source('ods', 'metadata_manager_individual') }} as idv on idv.orcabus_id = lnk.individual_orcabus_id
+    union
+    select library_id, subject_id as internal_subject_id from {{ ref('spreadsheet_library_tracking_metadata') }}
+    union
+    select library_id, subject_id as internal_subject_id from {{ ref('spreadsheet_google_lims') }}
 
 ),
 

--- a/orcavault/models/raw/link_library_project.sql
+++ b/orcavault/models/raw/link_library_project.sql
@@ -7,6 +7,10 @@ with source as (
     select lib.library_id as library_id, prj.project_id as project_id from {{ source('ods', 'metadata_manager_library') }} as lib
         join {{ source('ods', 'metadata_manager_libraryprojectlink') }} as lnk on lnk.library_orcabus_id = lib.orcabus_id
         join {{ source('ods', 'metadata_manager_project') }} as prj on lnk.project_orcabus_id = prj.orcabus_id
+    union
+    select library_id, project_name as project_id from {{ ref('spreadsheet_library_tracking_metadata') }}
+    union
+    select library_id, project_name as project_id from {{ ref('spreadsheet_google_lims') }}
 
 ),
 

--- a/orcavault/models/raw/link_library_sample.sql
+++ b/orcavault/models/raw/link_library_sample.sql
@@ -6,6 +6,10 @@ with source as (
     union
     select library_id, smp.sample_id as sample_id from {{ source('ods', 'metadata_manager_library') }} as lib
         join {{ source('ods', 'metadata_manager_sample') }} as smp on lib.sample_orcabus_id = smp.orcabus_id
+    union
+    select library_id, sample_id from {{ ref('spreadsheet_library_tracking_metadata') }}
+    union
+    select library_id, sample_id from {{ ref('spreadsheet_google_lims') }}
 
 ),
 

--- a/orcavault/models/raw/link_library_sequencing_run.sql
+++ b/orcavault/models/raw/link_library_sequencing_run.sql
@@ -3,6 +3,8 @@ with source as (
     select library_id, instrument_run_id as sequencing_run_id from {{ source('ods', 'data_portal_libraryrun') }}
     union
     select library_id, illumina_id as sequencing_run_id from {{ source('ods', 'data_portal_limsrow') }}
+    union
+    select library_id, illumina_id as sequencing_run_id from {{ ref('spreadsheet_google_lims') }}
 
 ),
 


### PR DESCRIPTION
* This consolidates all possible linkage centered around Library hub to
  the other hub entities from ODS and PSA spreadsheet transaction records.

Related #22
