### PR TITLE
Updated OrcaVault link models that exhibit internal-external mapping from PSA spreadsheet schema

### DIFF
--- a/orcavault/models/raw/link_internal_to_external_sample.sql
+++ b/orcavault/models/raw/link_internal_to_external_sample.sql
@@ -5,6 +5,10 @@ with source as (
     select sample_id, external_sample_id from {{ source('ods', 'data_portal_limsrow') }}
     union
     select sample_id, external_sample_id from {{ source('ods', 'metadata_manager_sample') }}
+    union
+    select sample_id, external_sample_id from {{ ref('spreadsheet_library_tracking_metadata') }}
+    union
+    select sample_id, external_sample_id from {{ ref('spreadsheet_google_lims') }}
 
 ),
 

--- a/orcavault/models/raw/link_internal_to_external_subject.sql
+++ b/orcavault/models/raw/link_internal_to_external_subject.sql
@@ -7,6 +7,10 @@ with source as (
     select idv.individual_id as internal_subject_id, sbj.subject_id as external_subject_id from {{ source('ods', 'metadata_manager_subject') }} as sbj
         join {{ source('ods', 'metadata_manager_subjectindividuallink') }} as lnk on lnk.subject_orcabus_id = sbj.orcabus_id
         join {{ source('ods', 'metadata_manager_individual') }} as idv on lnk.individual_orcabus_id = idv.orcabus_id
+    union
+    select subject_id as internal_subject_id, external_subject_id from {{ ref('spreadsheet_library_tracking_metadata') }}
+    union
+    select subject_id as internal_subject_id, external_subject_id from {{ ref('spreadsheet_google_lims') }}
 
 ),
 


### PR DESCRIPTION
* This consolidates all possible linkage centered around hub models that exhibit
  internal to external mapping from ODS and PSA spreadsheet transaction records.

Related #23
