### PR TITLE
Updated OrcaVault hub models incremental materialization

### DIFF
--- a/orcavault/models/raw/hub_external_sample.sql
+++ b/orcavault/models/raw/hub_external_sample.sql
@@ -1,8 +1,14 @@
-{{ config(
-    indexes=[
-      {'columns': ['external_sample_id'], 'type': 'btree'},
-    ]
-)}}
+{{
+    config(
+        indexes=[
+            {'columns': ['external_sample_id'], 'type': 'btree'},
+        ],
+        materialized='incremental',
+        incremental_strategy='merge',
+        unique_key='external_sample_id',
+        on_schema_change='fail'
+    )
+}}
 
 with source as (
 
@@ -19,7 +25,17 @@ with source as (
 ),
 
 cleaned as (
+
     select * from source where external_sample_id is not null and external_sample_id <> ''
+
+),
+
+differentiated as (
+
+    select external_sample_id from cleaned
+    except
+    select external_sample_id from {{ this }}
+
 ),
 
 transformed as (
@@ -30,12 +46,20 @@ transformed as (
         cast('{{ run_started_at }}' as timestamptz) as load_datetime,
         (select 'lab') as record_source
     from
-        cleaned
+        differentiated
 
 ),
 
 final as (
-    select * from transformed
+
+    select
+        cast(external_sample_hk as char(64)) as external_sample_hk,
+        cast(external_sample_id as varchar(255)) as external_sample_id,
+        cast(load_datetime as timestamptz) as load_datetime,
+        cast(record_source as varchar(255)) as record_source
+    from
+        transformed
+
 )
 
 select * from final

--- a/orcavault/models/raw/hub_external_subject.sql
+++ b/orcavault/models/raw/hub_external_subject.sql
@@ -1,8 +1,14 @@
-{{ config(
-    indexes=[
-      {'columns': ['external_subject_id'], 'type': 'btree'},
-    ]
-)}}
+{{
+    config(
+        indexes=[
+            {'columns': ['external_subject_id'], 'type': 'btree'},
+        ],
+        materialized='incremental',
+        incremental_strategy='merge',
+        unique_key='external_subject_id',
+        on_schema_change='fail'
+    )
+}}
 
 with source as (
 
@@ -19,7 +25,17 @@ with source as (
 ),
 
 cleaned as (
+
     select * from source where external_subject_id is not null and external_subject_id <> ''
+
+),
+
+differentiated as (
+
+    select external_subject_id from cleaned
+    except
+    select external_subject_id from {{ this }}
+
 ),
 
 transformed as (
@@ -30,12 +46,20 @@ transformed as (
         cast('{{ run_started_at }}' as timestamptz) as load_datetime,
         (select 'lab') as record_source
     from
-        cleaned
+        differentiated
 
 ),
 
 final as (
-    select * from transformed
+
+    select
+        cast(external_subject_hk as char(64)) as external_subject_hk,
+        cast(external_subject_id as varchar(255)) as external_subject_id,
+        cast(load_datetime as timestamptz) as load_datetime,
+        cast(record_source as varchar(255)) as record_source
+    from
+        transformed
+
 )
 
 select * from final

--- a/orcavault/models/raw/hub_internal_subject.sql
+++ b/orcavault/models/raw/hub_internal_subject.sql
@@ -1,8 +1,14 @@
-{{ config(
-    indexes=[
-      {'columns': ['internal_subject_id'], 'type': 'btree'},
-    ]
-)}}
+{{
+    config(
+        indexes=[
+            {'columns': ['internal_subject_id'], 'type': 'btree'},
+        ],
+        materialized='incremental',
+        incremental_strategy='merge',
+        unique_key='internal_subject_id',
+        on_schema_change='fail'
+    )
+}}
 
 with source as (
 
@@ -19,7 +25,17 @@ with source as (
 ),
 
 cleaned as (
+
     select * from source where internal_subject_id is not null and internal_subject_id <> ''
+
+),
+
+differentiated as (
+
+    select internal_subject_id from cleaned
+    except
+    select internal_subject_id from {{ this }}
+
 ),
 
 transformed as (
@@ -30,12 +46,20 @@ transformed as (
         cast('{{ run_started_at }}' as timestamptz) as load_datetime,
         (select 'lab') as record_source
     from
-        cleaned
+        differentiated
 
 ),
 
 final as (
-    select * from transformed
+
+    select
+        cast(internal_subject_hk as char(64)) as internal_subject_hk,
+        cast(internal_subject_id as varchar(255)) as internal_subject_id,
+        cast(load_datetime as timestamptz) as load_datetime,
+        cast(record_source as varchar(255)) as record_source
+    from
+        transformed
+
 )
 
 select * from final

--- a/orcavault/models/raw/hub_project.sql
+++ b/orcavault/models/raw/hub_project.sql
@@ -1,8 +1,14 @@
-{{ config(
-    indexes=[
-      {'columns': ['project_id'], 'type': 'btree'},
-    ]
-)}}
+{{
+    config(
+        indexes=[
+            {'columns': ['project_id'], 'type': 'btree'},
+        ],
+        materialized='incremental',
+        incremental_strategy='merge',
+        unique_key='project_id',
+        on_schema_change='fail'
+    )
+}}
 
 with source as (
 
@@ -19,7 +25,17 @@ with source as (
 ),
 
 cleaned as (
+
     select * from source where project_id is not null and project_id <> ''
+
+),
+
+differentiated as (
+
+    select project_id from cleaned
+    except
+    select project_id from {{ this }}
+
 ),
 
 transformed as (
@@ -30,12 +46,20 @@ transformed as (
         cast('{{ run_started_at }}' as timestamptz) as load_datetime,
         (select 'lab') as record_source
     from
-        cleaned
+        differentiated
 
 ),
 
 final as (
-    select * from transformed
+
+    select
+        cast(project_hk as char(64)) as project_hk,
+        cast(project_id as varchar(255)) as project_id,
+        cast(load_datetime as timestamptz) as load_datetime,
+        cast(record_source as varchar(255)) as record_source
+    from
+        transformed
+
 )
 
 select * from final

--- a/orcavault/models/raw/hub_schema.yml
+++ b/orcavault/models/raw/hub_schema.yml
@@ -1,6 +1,7 @@
 version: 2
 
 models:
+
   - name: hub_library
     config:
       contract: { enforced: true }

--- a/orcavault/models/raw/hub_sequencing_run.sql
+++ b/orcavault/models/raw/hub_sequencing_run.sql
@@ -1,8 +1,14 @@
-{{ config(
-    indexes=[
-      {'columns': ['sequencing_run_id'], 'type': 'btree'},
-    ]
-)}}
+{{
+    config(
+        indexes=[
+            {'columns': ['sequencing_run_id'], 'type': 'btree'},
+        ],
+        materialized='incremental',
+        incremental_strategy='merge',
+        unique_key='sequencing_run_id',
+        on_schema_change='fail'
+    )
+}}
 
 with source as (
 
@@ -21,7 +27,17 @@ with source as (
 ),
 
 cleaned as (
+
     select * from source where sequencing_run_id is not null and sequencing_run_id <> ''
+
+),
+
+differentiated as (
+
+    select sequencing_run_id from cleaned
+    except
+    select sequencing_run_id from {{ this }}
+
 ),
 
 transformed as (
@@ -32,12 +48,20 @@ transformed as (
         cast('{{ run_started_at }}' as timestamptz) as load_datetime,
         (select 'lab') as record_source
     from
-        cleaned
+        differentiated
 
 ),
 
 final as (
-    select * from transformed
+
+    select
+        cast(sequencing_run_hk as char(64)) as sequencing_run_hk,
+        cast(sequencing_run_id as varchar(255)) as sequencing_run_id,
+        cast(load_datetime as timestamptz) as load_datetime,
+        cast(record_source as varchar(255)) as record_source
+    from
+        transformed
+
 )
 
 select * from final


### PR DESCRIPTION
* This facilitates next encounter with hub business key (e.g. library_id) upon
  next day ELT run. The incremental materialization makes that warehouse already
  known the records and, therefore skip as appropriate. The incremental merge
  strategy gives, so that, hub models won't get delete+insert (dbt default setting);
  but gracefully merge with updatable aux columns such as load_datetime, record_source.
