### PR TITLE
Implemented OrcaVault Library satellite model - glab

### DIFF
--- a/orcavault/models/raw/sat_library_glab.sql
+++ b/orcavault/models/raw/sat_library_glab.sql
@@ -1,0 +1,126 @@
+{{
+    config(
+        materialized='incremental',
+        incremental_strategy='append',
+        on_schema_change='fail'
+    )
+}}
+
+with source as (
+
+    select distinct
+        record_source,
+        library_id,
+        workflow,
+        phenotype,
+        type,
+        assay,
+        quality,
+        source,
+        truseq_index
+    from
+        {{ ref('spreadsheet_library_tracking_metadata') }}
+
+),
+
+cleaned as (
+
+    select
+        record_source,
+        row_number() over (partition by library_id order by phenotype) as rank,
+        trim(regexp_replace(library_id, E'[\\n\\r]+', '', 'g')) as library_id,
+        trim(regexp_replace(workflow, E'[\\n\\r]+', '', 'g')) as workflow,
+        trim(regexp_replace(phenotype, E'[\\n\\r]+', '', 'g')) as phenotype,
+        trim(regexp_replace(type, E'[\\n\\r]+', '', 'g')) as type,
+        trim(regexp_replace(assay, E'[\\n\\r]+', '', 'g')) as assay,
+        trim(regexp_replace(quality, E'[\\n\\r]+', '', 'g')) as quality,
+        trim(regexp_replace(source, E'[\\n\\r]+', '', 'g')) as source,
+        trim(regexp_replace(truseq_index, E'[\\n\\r]+', '', 'g')) as truseq_index
+    from
+        source
+    where
+        library_id is not null or library_id <> ''
+
+),
+
+encoded as (
+
+    select
+        record_source,
+        encode(sha256(cast(library_id as bytea)), 'hex') as library_hk,
+        encode(sha256(concat(workflow, phenotype, type, assay, quality, source, truseq_index)::bytea), 'hex') as hash_diff,
+        workflow,
+        phenotype,
+        type,
+        assay,
+        quality,
+        source,
+        truseq_index
+    from
+        cleaned
+    where
+        rank = 1
+
+),
+
+differentiated as (
+
+    select
+        library_hk,
+        hash_diff
+    from
+        encoded
+    {% if is_incremental() %}
+    except
+    select
+        library_hk,
+        hash_diff
+    from
+        {{ this }}
+    {% endif %}
+
+),
+
+transformed as (
+
+    select
+        library_hk,
+        cast('{{ run_started_at }}' as timestamptz) as load_datetime,
+        record_source,
+        hash_diff,
+        workflow,
+        phenotype,
+        type,
+        assay,
+        quality,
+        source,
+        truseq_index
+    from
+        encoded
+    {% if is_incremental() %}
+    where
+        library_hk in (select library_hk from differentiated)
+    {% endif %}
+
+),
+
+final as (
+
+    select
+        cast(library_hk as char(64)) as library_hk,
+        cast(load_datetime as timestamptz) as load_datetime,
+        cast(record_source as varchar(255)) as record_source,
+        cast(hash_diff as char(64)) as hash_diff,
+        cast(workflow as varchar(255)) as workflow,
+        cast(phenotype as varchar(255)) as phenotype,
+        cast(type as varchar(255)) as type,
+        cast(assay as varchar(255)) as assay,
+        cast(quality as varchar(255)) as quality,
+        cast(source as varchar(255)) as source,
+        cast(truseq_index as varchar(255)) as truseq_index
+    from
+        transformed
+
+)
+
+select * from final

--- a/orcavault/models/raw/sat_schema.yml
+++ b/orcavault/models/raw/sat_schema.yml
@@ -101,3 +101,37 @@ models:
         data_type: varchar(255)
       - name: source
         data_type: varchar(255)
+
+  - name: sat_library_glab
+    config:
+      contract: { enforced: true }
+    constraints:
+      - type: primary_key
+        columns: [ library_hk, load_datetime ]
+      - type: foreign_key
+        columns: [ library_hk ]
+        to: ref('hub_library')
+        to_columns: [ library_hk ]
+    columns:
+      - name: library_hk
+        data_type: char(64)
+      - name: load_datetime
+        data_type: timestamptz
+      - name: record_source
+        data_type: varchar(255)
+      - name: hash_diff
+        data_type: char(64)
+      - name: workflow
+        data_type: varchar(255)
+      - name: phenotype
+        data_type: varchar(255)
+      - name: type
+        data_type: varchar(255)
+      - name: assay
+        data_type: varchar(255)
+      - name: quality
+        data_type: varchar(255)
+      - name: source
+        data_type: varchar(255)
+      - name: truseq_index
+        data_type: varchar(255)


### PR DESCRIPTION
* Satellite record source is PSA spreadsheet_library_tracking_metadata. Hence, shorthand `_glab` suffix.
* Similarly to #31
  Except, it is the most original interpretation about the Library entity description that warehouse get.
* Slightly tailored incremental loading strategy needed to use; by ranking with phenotype column to reduce
  duplicate for the initial data load_datetime.
