### PR TITLE
Implemented OrcaVault ExternalSubject satellite model - mm

### DIFF
--- a/orcavault/models/raw/sat_schema.yml
+++ b/orcavault/models/raw/sat_schema.yml
@@ -299,3 +299,25 @@ models:
         data_type: varchar(255)
       - name: email
         data_type: varchar(255)
+
+  - name: sat_subject_mm
+    config:
+      contract: { enforced: true }
+    constraints:
+      - type: primary_key
+        columns: [ external_subject_hk, load_datetime ]
+      - type: foreign_key
+        columns: [ external_subject_hk ]
+        to: ref('hub_external_subject')
+        to_columns: [ external_subject_hk ]
+    columns:
+      - name: external_subject_hk
+        data_type: char(64)
+      - name: load_datetime
+        data_type: timestamptz
+      - name: record_source
+        data_type: varchar(255)
+      - name: hash_diff
+        data_type: char(64)
+      - name: orcabus_id
+        data_type: varchar(255)

--- a/orcavault/models/raw/sat_subject_mm.sql
+++ b/orcavault/models/raw/sat_subject_mm.sql
@@ -1,0 +1,88 @@
+{{
+    config(
+        materialized='incremental',
+        incremental_strategy='append',
+        on_schema_change='fail'
+    )
+}}
+
+with source as (
+
+    select
+        subject_id as external_subject_id,
+        orcabus_id
+    from
+        {{ source('ods', 'metadata_manager_subject') }}
+
+),
+
+cleaned as (
+
+    select
+        trim(regexp_replace(external_subject_id, E'[\\n\\r]+', '', 'g')) as external_subject_id,
+        trim(regexp_replace(orcabus_id, E'[\\n\\r]+', '', 'g')) as orcabus_id
+    from
+        source
+
+),
+
+encoded as (
+
+    select
+        encode(sha256(cast(external_subject_id as bytea)), 'hex') as external_subject_hk,
+        encode(sha256(concat(orcabus_id)::bytea), 'hex') as hash_diff,
+        orcabus_id
+    from
+        cleaned
+
+),
+
+differentiated as (
+
+    select
+        external_subject_hk,
+        hash_diff
+    from
+        encoded
+    {% if is_incremental() %}
+    except
+    select
+        external_subject_hk,
+        hash_diff
+    from
+        {{ this }}
+    {% endif %}
+
+),
+
+transformed as (
+
+    select
+        external_subject_hk,
+        cast('{{ run_started_at }}' as timestamptz) as load_datetime,
+        (select 'metadata_manager_subject') as record_source,
+        hash_diff,
+        orcabus_id
+    from
+        encoded
+    {% if is_incremental() %}
+    where
+        external_subject_hk in (select external_subject_hk from differentiated)
+    {% endif %}
+
+),
+
+final as (
+
+    select
+        cast(external_subject_hk as char(64)) as external_subject_hk,
+        cast(load_datetime as timestamptz) as load_datetime,
+        cast(record_source as varchar(255)) as record_source,
+        cast(hash_diff as char(64)) as hash_diff,
+        cast(orcabus_id as varchar(255)) as orcabus_id
+    from
+        transformed
+
+)
+
+select * from final


### PR DESCRIPTION
* Record source is Metadata Manager, hence, follows `_mm` suffix.
* ExternalSubject satellite model for `hub_external_subject` that track
  change history details about the ExternalSubject descriptive attributes
  by Metadata Manager application.
* Chiefly note, ExternalSubject concept is renamed in Metadata Manager; hence
  model name `sat_subject_mm` itself to distinguish and track this concept changes.
