### PR TITLE
Implemented OrcaVault InternalSubject satellite model - mm

### DIFF
--- a/orcavault/models/raw/sat_individual_mm.sql
+++ b/orcavault/models/raw/sat_individual_mm.sql
@@ -1,0 +1,93 @@
+{{
+    config(
+        materialized='incremental',
+        incremental_strategy='append',
+        on_schema_change='fail'
+    )
+}}
+
+with source as (
+
+    select
+        individual_id as internal_subject_id,
+        orcabus_id,
+        source
+    from
+        {{ source('ods', 'metadata_manager_individual') }}
+
+),
+
+cleaned as (
+
+    select
+        trim(regexp_replace(internal_subject_id, E'[\\n\\r]+', '', 'g')) as internal_subject_id,
+        trim(regexp_replace(orcabus_id, E'[\\n\\r]+', '', 'g')) as orcabus_id,
+        trim(regexp_replace(source, E'[\\n\\r]+', '', 'g')) as source
+    from
+        source
+
+),
+
+encoded as (
+
+    select
+        encode(sha256(cast(internal_subject_id as bytea)), 'hex') as internal_subject_hk,
+        encode(sha256(concat(orcabus_id, source)::bytea), 'hex') as hash_diff,
+        orcabus_id,
+        source
+    from
+        cleaned
+
+),
+
+differentiated as (
+
+    select
+        internal_subject_hk,
+        hash_diff
+    from
+        encoded
+    {% if is_incremental() %}
+    except
+    select
+        internal_subject_hk,
+        hash_diff
+    from
+        {{ this }}
+    {% endif %}
+
+),
+
+transformed as (
+
+    select
+        internal_subject_hk,
+        cast('{{ run_started_at }}' as timestamptz) as load_datetime,
+        (select 'metadata_manager_individual') as record_source,
+        hash_diff,
+        orcabus_id,
+        source
+    from
+        encoded
+    {% if is_incremental() %}
+    where
+        internal_subject_hk in (select internal_subject_hk from differentiated)
+    {% endif %}
+
+),
+
+final as (
+
+    select
+        cast(internal_subject_hk as char(64)) as internal_subject_hk,
+        cast(load_datetime as timestamptz) as load_datetime,
+        cast(record_source as varchar(255)) as record_source,
+        cast(hash_diff as char(64)) as hash_diff,
+        cast(orcabus_id as varchar(255)) as orcabus_id,
+        cast(source as varchar(255)) as source
+    from
+        transformed
+
+)
+
+select * from final

--- a/orcavault/models/raw/sat_schema.yml
+++ b/orcavault/models/raw/sat_schema.yml
@@ -321,3 +321,27 @@ models:
         data_type: char(64)
       - name: orcabus_id
         data_type: varchar(255)
+
+  - name: sat_individual_mm
+    config:
+      contract: { enforced: true }
+    constraints:
+      - type: primary_key
+        columns: [ internal_subject_hk, load_datetime ]
+      - type: foreign_key
+        columns: [ internal_subject_hk ]
+        to: ref('hub_internal_subject')
+        to_columns: [ internal_subject_hk ]
+    columns:
+      - name: internal_subject_hk
+        data_type: char(64)
+      - name: load_datetime
+        data_type: timestamptz
+      - name: record_source
+        data_type: varchar(255)
+      - name: hash_diff
+        data_type: char(64)
+      - name: orcabus_id
+        data_type: varchar(255)
+      - name: source
+        data_type: varchar(255)


### PR DESCRIPTION
* Record source is Metadata Manager, hence, follows `_mm` suffix.
* InternalSubject satellite model for `hub_internal_subject` that track
  change history details about the InternalSubject descriptive attributes
  by Metadata Manager application.
* Chiefly note, InternalSubject concept is renamed in Metadata Manager; hence
  model name `sat_individual_mm` itself to reflect and track this concept changes.

Related #39
