### PR TITLE
Implemented OrcaHouse Aurora database backup

### DIFF
--- a/infra/aurora/backup.tf
+++ b/infra/aurora/backup.tf
@@ -1,0 +1,65 @@
+################################################################################
+# AWS Backup configuration for Aurora DB
+
+data "aws_kms_key" "backup" {
+  key_id = "alias/aws/backup"
+}
+
+resource "aws_iam_role" "db_backup_role" {
+  name               = "${local.stack_name}-backup-role"
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": ["sts:AssumeRole"],
+      "Effect": "allow",
+      "Principal": {
+        "Service": ["backup.amazonaws.com"]
+      }
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "db_backup_role_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
+  role       = aws_iam_role.db_backup_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "db_backup_role_restore_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores"
+  role       = aws_iam_role.db_backup_role.name
+}
+
+resource "aws_backup_vault" "db_backup_vault" {
+  name  = "${local.stack_name}-backup-vault"
+  kms_key_arn = data.aws_kms_key.backup.arn
+}
+
+resource "aws_backup_plan" "db_backup_plan" {
+  name  = "${local.stack_name}-backup-plan"
+
+  // Backup weekly and keep it for 6 weeks
+  // Cron At 17:00 on every Sunday UTC = AEST/AEDT 3AM/4AM on every Monday
+  rule {
+    rule_name         = "Weekly"
+    target_vault_name = aws_backup_vault.db_backup_vault.name
+    schedule          = "cron(0 17 ? * SUN *)"
+
+    lifecycle {
+      delete_after = 42
+    }
+  }
+}
+
+resource "aws_backup_selection" "db_backup" {
+  name         = "${local.stack_name}-backup"
+  plan_id      = aws_backup_plan.db_backup_plan.id
+  iam_role_arn = aws_iam_role.db_backup_role.arn
+
+  resources = [
+    aws_rds_cluster.this.arn,
+  ]
+}

--- a/infra/aurora/main.tf
+++ b/infra/aurora/main.tf
@@ -105,9 +105,10 @@ resource "aws_rds_cluster" "this" {
   master_username             = data.aws_ssm_parameter.master_username.value
   manage_master_user_password = true
   db_subnet_group_name        = aws_db_subnet_group.this.name
-  backup_retention_period     = 1
+  backup_retention_period     = 7
   deletion_protection         = true
   storage_encrypted           = true
+  enable_http_endpoint        = true
 
   vpc_security_group_ids = [
     aws_security_group.this.id,
@@ -117,7 +118,7 @@ resource "aws_rds_cluster" "this" {
 
   serverlessv2_scaling_configuration {
     min_capacity = 0.5
-    max_capacity = 4.0
+    max_capacity = 16.0
   }
 }
 


### PR DESCRIPTION
* Now that we are running daily ETL workload, it is time to enable
  database backup. It follows usual convention 7 days point-in-time
  recovery and, tier-2 AWS Backup on weekly snapshots upto 6 weeks
  retention.
* Enabled RDS Data API for Query Editor via RDS Console
