### PR TITLE
Added aurora user orcahouse ro

### DIFF
--- a/infra/aurora-su/main.tf
+++ b/infra/aurora-su/main.tf
@@ -29,9 +29,17 @@ provider "aws" {
 }
 
 locals {
-  stack_name                 = "orcahouse"
-  sorted_private_subnets     = sort(data.aws_subnets.private_subnets_ids.ids)
+  stack_name = "orcahouse"
+
+  sorted_private_subnets = sort(data.aws_subnets.private_subnets_ids.ids)
+
   selected_private_subnet_id = local.sorted_private_subnets[0]
+
+  orcahouse_db_sg_id = {
+    dev  = ""
+    prod = "sg-013b6e66086adc6a6"
+    stg  = ""
+  }
 }
 
 data "aws_partition" "current" {}
@@ -88,12 +96,4 @@ data "aws_serverlessapplicationrepository_application" "this" {
   # https://docs.aws.amazon.com/secretsmanager/latest/userguide/reference_available-rotation-templates.html
   # https://serverlessrepo.aws.amazon.com/applications/us-east-1/297356227824/SecretsManagerRDSPostgreSQLRotationSingleUser
   application_id = "arn:aws:serverlessrepo:us-east-1:297356227824:applications/SecretsManagerRDSPostgreSQLRotationSingleUser"
-}
-
-variable "orcabus_compute_sg_id" {
-  default = {
-    dev  = ""
-    prod = "sg-02e363a39220c955f"
-    stg  = ""
-  }
 }


### PR DESCRIPTION
* Following terraform `aurora-su` service user stack to add read
  only service user at OrcaHouse level. Further permissions are
  configured at PostgreSQL for table and schema ACL.
* Refactored orcabus_compute_sg_id to orcahouse_db_sg_id to
  decouple external SG resource dependency.
