### PR TITLE
Implemented OrcaHouse Athena

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # OrcaHouse 
 
 Enterprise Data Warehouse Project
+
+For user guide and project documentation, please refer to https://github.com/umccr/orcahouse-doc

--- a/infra/athena/.terraform.lock.hcl
+++ b/infra/athena/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.78.0"
+  constraints = "5.78.0"
+  hashes = [
+    "h1:o7jz+dFixEcwjfdubken5ldmDJm1tkvM2adPtNDei3g=",
+    "zh:0ae7d41b96441d0cf7ce2e1337657bdb2e1e5c9f1c2227b0642e1dcec2f9dfba",
+    "zh:21f8f1edf477681ea3b095c02cad6b8e85262e45015de58e84e0c7b2bfe9a1f6",
+    "zh:2bdc335e341bf98445255549ae93d66cfb9bca706e62b949da98fe467c182cad",
+    "zh:2fe4096e260367a225a9faf4a424d62b87e5498f12cb43bdb6f4e713d11b82c3",
+    "zh:3c63bb7a7925d65118d17461f4691a22dbb55ea39a7404e4d71f6ccca8765f8b",
+    "zh:6609a28a1c638a1901d8007b5386868ccfd313b4df2e98b35d9fdef436974e3b",
+    "zh:7ae3aef43bc4b365824cca4659cf92459d766800656e354bdbf83feabab835e8",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:c314efe454adc6ca483261c6906e64315aeb9db0c0332818714e9b81e07df0f0",
+    "zh:cd3e30396b554bbc1d260252db8a0f344065d619038fe60ea870689cd32c6aa9",
+    "zh:d1ba48fd9d8a1cb1daa927fb9e8bb708b857f2792d796e110460c6fdcd896a47",
+    "zh:d31c8abe75cb9cdc1c59ad9d356a1c3ae1ba8cd29ac15eb7e01b6cd01221ab04",
+    "zh:dc27c5c2116b4d9b404753f73bccaa635bce21f3bfb4bb7bc8e63225c36c98fe",
+    "zh:de491f0d05408378413187475c815d8cb2ac6bfa63d0b42a30ad5ee492e51c07",
+    "zh:eb44b45a40f80a309dd5b0eb7d7fcb2cbfe588fe2f18b173ef5851346898a662",
+  ]
+}

--- a/infra/athena/README.md
+++ b/infra/athena/README.md
@@ -1,0 +1,24 @@
+# OrcaHouse Athena
+
+See https://docs.aws.amazon.com/athena/latest/ug/federated-queries.html
+
+To establish another federated Data Source for OrcaHouse Athena, just simply replicate `orcavault.tf` and adjust the setup accordingly.
+
+Like so.
+
+```
+cp orcavault.tf anothervault.tf
+```
+
+The stack uses terraform workspace.
+
+```
+terraform workspace list
+  default
+* prod
+```
+
+```
+export AWS_PROFILE=umccr-prod-admin && terraform workspace select prod && terraform plan
+terraform apply
+```

--- a/infra/athena/main.tf
+++ b/infra/athena/main.tf
@@ -1,0 +1,116 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  backend "s3" {
+    bucket         = "umccr-terraform-states"
+    key            = "orcahouse-athena/terraform.tfstate"
+    region         = "ap-southeast-2"
+    dynamodb_table = "terraform-state-lock"
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.78.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "ap-southeast-2"
+  default_tags {
+    tags = {
+      "umccr-org:Product" = "OrcaHouse"
+      "umccr-org:Creator" = "Terraform"
+      "umccr-org:Service" = "OrcaHouse"
+      "umccr-org:Source"  = "https://github.com/umccr/orcahouse"
+    }
+  }
+}
+
+locals {
+  stack_name = "orcahouse"
+
+  sorted_private_subnets = sort(data.aws_subnets.private_subnets_ids.ids)
+
+  selected_private_subnet_id = local.sorted_private_subnets[0]
+
+  orcahouse_db_sg_id = {
+    dev  = ""
+    prod = "sg-013b6e66086adc6a6"
+    stg  = ""
+  }
+
+  orcahouse_staging_bucket = {
+    dev  = ""
+    prod = "orcahouse-staging-data-472057503814"
+    stg  = ""
+  }
+}
+
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_vpc" "main_vpc" {
+  # Using tags filter on networking stack to get main-vpc
+  tags = {
+    Name        = "main-vpc"
+    Stack       = "networking"
+    Environment = terraform.workspace
+  }
+}
+
+data "aws_subnets" "private_subnets_ids" {
+  filter {
+    name = "vpc-id"
+    values = [data.aws_vpc.main_vpc.id]
+  }
+
+  tags = {
+    Tier = "private"
+  }
+}
+
+data "aws_subnet" "selected" {
+  id = local.selected_private_subnet_id
+}
+
+data "aws_s3_bucket" "staging_data" {
+  bucket = local.orcahouse_staging_bucket[terraform.workspace]
+}
+
+data "aws_rds_cluster" "orcahouse_db" {
+  cluster_identifier = "orcahouse-db"
+}
+
+data "aws_ssm_parameter" "ro_username" {
+  name = "/${local.stack_name}/ro_username"
+}
+
+data "aws_secretsmanager_secret" "ro" {
+  name = "${local.stack_name}/${data.aws_ssm_parameter.ro_username.value}"
+}
+
+data "aws_serverlessapplicationrepository_application" "this" {
+  # https://serverlessrepo.aws.amazon.com/applications/us-east-1/292517598671/AthenaPostgreSQLConnector
+  application_id = "arn:aws:serverlessrepo:us-east-1:292517598671:applications/AthenaPostgreSQLConnector"
+}
+
+resource "aws_athena_workgroup" "orcahouse" {
+  name        = local.stack_name
+  description = "${local.stack_name} athena workgroup"
+
+  configuration {
+    enforce_workgroup_configuration    = true
+    publish_cloudwatch_metrics_enabled = true
+
+    result_configuration {
+      output_location = "s3://${data.aws_s3_bucket.staging_data.bucket}/athena-query-results/"
+
+      encryption_configuration {
+        encryption_option = "SSE_S3"
+      }
+    }
+  }
+}

--- a/infra/athena/orcavault.tf
+++ b/infra/athena/orcavault.tf
@@ -1,0 +1,38 @@
+locals {
+  # https://docs.aws.amazon.com/athena/latest/ug/understanding-tables-databases-and-the-data-catalog.html
+  catalog_name = "orcavault"
+}
+
+resource "aws_serverlessapplicationrepository_cloudformation_stack" "orcavault" {
+  name             = "AthenaPostgreSQLConnectorForOrcaVault"
+  application_id   = data.aws_serverlessapplicationrepository_application.this.id
+  semantic_version = data.aws_serverlessapplicationrepository_application.this.semantic_version
+  capabilities     = data.aws_serverlessapplicationrepository_application.this.required_capabilities
+
+  # https://docs.aws.amazon.com/athena/latest/ug/connectors-postgresql.html
+  # https://github.com/awslabs/aws-athena-query-federation/blob/cd2fa85/athena-postgresql/athena-postgresql.yaml
+  parameters = {
+    DefaultConnectionString = "postgres://jdbc:postgresql://${data.aws_rds_cluster.orcahouse_db.reader_endpoint}:5432/${local.catalog_name}?$${${data.aws_secretsmanager_secret.ro.name}}"
+    LambdaFunctionName      = local.catalog_name
+    SecretNamePrefix        = data.aws_secretsmanager_secret.ro.name
+    SpillBucket             = data.aws_s3_bucket.staging_data.bucket
+    SecurityGroupIds        = local.orcahouse_db_sg_id[terraform.workspace]
+
+    SubnetIds = join(",", data.aws_subnets.private_subnets_ids.ids)
+  }
+
+  # uncomment to update latest connector version
+  lifecycle {
+    ignore_changes = [semantic_version,]
+  }
+}
+
+resource "aws_athena_data_catalog" "orcavault" {
+  name        = local.catalog_name
+  description = "${local.stack_name} athena data catalog: ${local.catalog_name}"
+  type        = "LAMBDA"
+
+  parameters = {
+    "function" = "arn:aws:lambda:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:function:${local.catalog_name}"
+  }
+}


### PR DESCRIPTION
* OrcaHouse Athena setup follows similar its predecessor Portal Athena
  and, it is the replacement service for decommissioning Portal.
* The setup gets much more expanded for catering more databases. The Athena
  Workgroup configured at "House" level artifacts to share across warehouses.
* It is configured to start with OrcaVault as the first warehouse to offer
  Athena query federation mechanism.
  https://docs.aws.amazon.com/athena/latest/ug/federated-queries.html
