### PR TITLE
Implemented raw vault layer workflow run hub model

### DIFF
--- a/orcavault/models/raw/hub_schema.yml
+++ b/orcavault/models/raw/hub_schema.yml
@@ -146,6 +146,22 @@ models:
       - name: record_source
         data_type: varchar(255)
 
+  - name: hub_workflow_run
+    config:
+      contract: { enforced: true }
+    constraints:
+      - type: primary_key
+        columns: [ workflow_run_hk ]
+    columns:
+      - name: workflow_run_hk
+        data_type: char(64)
+      - name: portal_run_id
+        data_type: char(16)
+      - name: load_datetime
+        data_type: timestamptz
+      - name: record_source
+        data_type: varchar(255)
+
   - name: hub_s3object
     config:
       contract: { enforced: true }

--- a/orcavault/models/raw/hub_workflow_run.sql
+++ b/orcavault/models/raw/hub_workflow_run.sql
@@ -1,0 +1,72 @@
+{{
+    config(
+        indexes=[
+            {'columns': ['portal_run_id'], 'type': 'btree'},
+        ],
+        materialized='incremental',
+        incremental_strategy='merge',
+        unique_key='workflow_run_hk',
+        on_schema_change='fail'
+    )
+}}
+
+with source1 as (
+
+    select
+        portal_run_id
+    from
+        {{ source('ods', 'data_portal_workflow') }}
+    {% if is_incremental() %}
+    where
+        cast(start as timestamptz) > ( select coalesce(max(load_datetime), '1900-01-01') as ldts from {{ this }} )
+    {% endif %}
+
+),
+
+source2 as (
+
+    select
+        portal_run_id
+    from {{ source('ods', 'workflow_manager_workflowrun') }} wfr
+        join {{ source('ods', 'workflow_manager_state') }} stt on stt.workflow_run_id = wfr.orcabus_id
+    {% if is_incremental() %}
+    where
+        cast(stt.timestamp as timestamptz) > ( select coalesce(max(load_datetime), '1900-01-01') as ldts from {{ this }} )
+    {% endif %}
+
+),
+
+combined as (
+
+    select distinct portal_run_id from source1
+    union
+    select distinct portal_run_id from source2
+
+),
+
+transformed as (
+
+    select
+        encode(sha256(cast(portal_run_id as bytea)), 'hex') as workflow_run_hk,
+        portal_run_id,
+        cast('{{ run_started_at }}' as timestamptz) as load_datetime,
+        (select 'portal_workflow_manager') as record_source
+    from
+        combined
+    order by portal_run_id
+
+),
+
+final as (
+
+    select
+        cast(workflow_run_hk as char(64)) as workflow_run_hk,
+        cast(portal_run_id as char(16)) as portal_run_id,
+        cast(load_datetime as timestamptz) as load_datetime,
+        cast(record_source as varchar(255)) as record_source
+    from
+        transformed
+
+)
+
+select * from final


### PR DESCRIPTION
* By centering at the `portal_run_id` column as hub business key, we source
  and combine both Portal (legacy) and Workflow Manager analysis run records.
  Details about each portal_run_id record will be modelled in their specific
  Satellite table and, we can establish Link table to Library hub.
* Made use of respective time columns for incremental load and change data capture
