### PR TITLE
Implemented raw vault Satellite model for hub_workflow_run - Workflow Manager

### DIFF
--- a/orcavault/models/raw/sat_schema.yml
+++ b/orcavault/models/raw/sat_schema.yml
@@ -479,3 +479,91 @@ models:
         data_type: jsonb
       - name: output_json
         data_type: jsonb
+
+  - name: sat_workflow_run_detail
+    config:
+      contract: { enforced: true }
+    constraints:
+      - type: primary_key
+        columns: [ workflow_run_hk, workflow_run_sq, load_datetime ]
+      - type: foreign_key
+        columns: [ workflow_run_hk ]
+        to: ref('hub_workflow_run')
+        to_columns: [ workflow_run_hk ]
+    columns:
+      - name: workflow_run_hk
+        data_type: char(64)
+      - name: workflow_run_sq
+        data_type: char(64)
+      - name: load_datetime
+        data_type: timestamptz
+      - name: record_source
+        data_type: varchar(255)
+      - name: hash_diff
+        data_type: char(64)
+      - name: workflow_run_orcabus_id
+        data_type: char(26)
+      - name: workflow_run_execution_id
+        data_type: varchar(255)
+      - name: workflow_run_name
+        data_type: varchar(255)
+      - name: workflow_run_comment
+        data_type: varchar(255)
+      - name: workflow_orcabus_id
+        data_type: char(26)
+      - name: workflow_name
+        data_type: varchar(255)
+      - name: workflow_version
+        data_type: varchar(255)
+      - name: workflow_execution_engine
+        data_type: varchar(255)
+      - name: workflow_execution_engine_pipeline_id
+        data_type: varchar(255)
+      - name: state_orcabus_id
+        data_type: char(26)
+      - name: state_status
+        data_type: varchar(255)
+      - name: state_timestamp
+        data_type: timestamptz
+      - name: state_comment
+        data_type: varchar(255)
+      - name: payload_orcabus_id
+        data_type: char(26)
+      - name: payload_ref_id
+        data_type: varchar(255)
+      - name: payload_version
+        data_type: varchar(255)
+      - name: payload_data
+        data_type: jsonb
+
+  - name: sat_workflow_run_comment
+    config:
+      contract: { enforced: true }
+    constraints:
+      - type: primary_key
+        columns: [ workflow_run_hk, load_datetime ]
+      - type: foreign_key
+        columns: [ workflow_run_hk ]
+        to: ref('hub_workflow_run')
+        to_columns: [ workflow_run_hk ]
+    columns:
+      - name: workflow_run_hk
+        data_type: char(64)
+      - name: load_datetime
+        data_type: timestamptz
+      - name: record_source
+        data_type: varchar(255)
+      - name: hash_diff
+        data_type: char(64)
+      - name: orcabus_id
+        data_type: char(26)
+      - name: comment
+        data_type: text
+      - name: created_at
+        data_type: timestamptz
+      - name: created_by
+        data_type: varchar(255)
+      - name: updated_at
+        data_type: timestamptz
+      - name: is_deleted
+        data_type: boolean

--- a/orcavault/models/raw/sat_workflow_run_comment.sql
+++ b/orcavault/models/raw/sat_workflow_run_comment.sql
@@ -1,0 +1,71 @@
+{{
+    config(
+        materialized='incremental',
+        incremental_strategy='append',
+        on_schema_change='fail'
+    )
+}}
+
+with source as (
+
+    select
+        wfr.portal_run_id as portal_run_id,
+        cmt.orcabus_id as orcabus_id,
+        cmt.comment as comment,
+        cmt.created_at as created_at,
+        cmt.created_by as created_by,
+        cmt.updated_at as updated_at,
+        cmt.is_deleted as is_deleted
+    from {{ source('ods', 'workflow_manager_workflowrun') }} wfr
+        join {{ source('ods', 'workflow_manager_workflowruncomment') }} cmt on cmt.workflow_run_id = wfr.orcabus_id
+    {% if is_incremental() %}
+    where
+        cast(cmt.created_at as timestamptz) > ( select coalesce(max(load_datetime), '1900-01-01') as ldts from {{ this }} )
+    {% endif %}
+
+),
+
+transformed as (
+
+    select
+        encode(sha256(cast(portal_run_id as bytea)), 'hex') as workflow_run_hk,
+        cast('{{ run_started_at }}' as timestamptz) as load_datetime,
+        (select 'workflow_manager_workflowruncomment') as record_source,
+        encode(sha256(concat(
+            orcabus_id,
+            comment,
+            created_at,
+            created_by,
+            updated_at,
+            is_deleted
+        )::bytea), 'hex') as hash_diff,
+        orcabus_id,
+        comment,
+        created_at,
+        created_by,
+        updated_at,
+        is_deleted
+    from
+        source
+
+),
+
+final as (
+
+    select
+        cast(workflow_run_hk as char(64)) as workflow_run_hk,
+        cast(load_datetime as timestamptz) as load_datetime,
+        cast(record_source as varchar(255)) as record_source,
+        cast(hash_diff as char(64)) as hash_diff,
+        cast(orcabus_id as char(26)) as orcabus_id,
+        cast(comment as text) as comment,
+        cast(created_at as timestamptz) as created_at,
+        cast(created_by as varchar(255)) as created_by,
+        cast(updated_at as timestamptz) as updated_at,
+        cast(is_deleted as boolean) as is_deleted
+    from
+        transformed
+
+)
+
+select * from final

--- a/orcavault/models/raw/sat_workflow_run_detail.sql
+++ b/orcavault/models/raw/sat_workflow_run_detail.sql
@@ -1,0 +1,118 @@
+{{
+    config(
+        materialized='incremental',
+        incremental_strategy='append',
+        on_schema_change='fail'
+    )
+}}
+
+with source as (
+
+    select
+        wfr.portal_run_id as portal_run_id,
+        wfr.orcabus_id as workflow_run_orcabus_id,
+        wfr.execution_id as workflow_run_execution_id,
+        wfr.workflow_run_name as workflow_run_name,
+        wfr.comment as workflow_run_comment,
+        wfl.orcabus_id as workflow_orcabus_id,
+        wfl.workflow_name as workflow_name,
+        wfl.workflow_version as workflow_version,
+        wfl.execution_engine as workflow_execution_engine,
+        wfl.execution_engine_pipeline_id as workflow_execution_engine_pipeline_id,
+        stt.orcabus_id as state_orcabus_id,
+        stt.status as state_status,
+        stt.timestamp as state_timestamp,
+        stt.comment as state_comment,
+        pld.orcabus_id as payload_orcabus_id,
+        pld.payload_ref_id as payload_ref_id,
+        pld.version as payload_version,
+        pld.data as payload_data
+    from {{ source('ods', 'workflow_manager_workflowrun') }} wfr
+        join {{ source('ods', 'workflow_manager_workflow') }} wfl on wfl.orcabus_id = wfr.workflow_id
+        join {{ source('ods', 'workflow_manager_state') }} stt on stt.workflow_run_id = wfr.orcabus_id
+        join {{ source('ods', 'workflow_manager_payload') }} pld on pld.orcabus_id = stt.payload_id
+    {% if is_incremental() %}
+    where
+        cast(stt.timestamp as timestamptz) > ( select coalesce(max(load_datetime), '1900-01-01') as ldts from {{ this }} )
+    {% endif %}
+
+),
+
+transformed as (
+
+    select
+        encode(sha256(cast(portal_run_id as bytea)), 'hex') as workflow_run_hk,
+        encode(sha256(cast(state_orcabus_id as bytea)), 'hex') as workflow_run_sq,
+        cast('{{ run_started_at }}' as timestamptz) as load_datetime,
+        (select 'workflow_manager') as record_source,
+        encode(sha256(concat(
+            workflow_run_orcabus_id,
+            workflow_run_execution_id,
+            workflow_run_name,
+            workflow_run_comment,
+            workflow_orcabus_id,
+            workflow_name,
+            workflow_version,
+            workflow_execution_engine,
+            workflow_execution_engine_pipeline_id,
+            state_orcabus_id,
+            state_status,
+            state_timestamp,
+            state_comment,
+            payload_orcabus_id,
+            payload_ref_id,
+            payload_version
+        )::bytea), 'hex') as hash_diff,
+        workflow_run_orcabus_id,
+        workflow_run_execution_id,
+        workflow_run_name,
+        workflow_run_comment,
+        workflow_orcabus_id,
+        workflow_name,
+        workflow_version,
+        workflow_execution_engine,
+        workflow_execution_engine_pipeline_id,
+        state_orcabus_id,
+        state_status,
+        state_timestamp,
+        state_comment,
+        payload_orcabus_id,
+        payload_ref_id,
+        payload_version,
+        payload_data
+    from
+        source
+
+),
+
+final as (
+
+    select
+        cast(workflow_run_hk as char(64)) as workflow_run_hk,
+        cast(workflow_run_sq as char(64)) as workflow_run_sq,
+        cast(load_datetime as timestamptz) as load_datetime,
+        cast(record_source as varchar(255)) as record_source,
+        cast(hash_diff as char(64)) as hash_diff,
+        cast(workflow_run_orcabus_id as char(26)) as workflow_run_orcabus_id,
+        cast(workflow_run_execution_id as varchar(255)) as workflow_run_execution_id,
+        cast(workflow_run_name as varchar(255)) as workflow_run_name,
+        cast(workflow_run_comment as varchar(255)) as workflow_run_comment,
+        cast(workflow_orcabus_id as char(26)) as workflow_orcabus_id,
+        cast(workflow_name as varchar(255)) as workflow_name,
+        cast(workflow_version as varchar(255)) as workflow_version,
+        cast(workflow_execution_engine as varchar(255)) as workflow_execution_engine,
+        cast(workflow_execution_engine_pipeline_id as varchar(255)) as workflow_execution_engine_pipeline_id,
+        cast(state_orcabus_id as varchar(26)) as state_orcabus_id,
+        cast(state_status as varchar(255)) as state_status,
+        cast(state_timestamp as timestamptz) as state_timestamp,
+        cast(state_comment as varchar(255)) as state_comment,
+        cast(payload_orcabus_id as char(26)) as payload_orcabus_id,
+        cast(payload_ref_id as varchar(255)) as payload_ref_id,
+        cast(payload_version as varchar(255)) as payload_version,
+        cast(payload_data as jsonb) as payload_data
+    from
+        transformed
+
+)
+
+select * from final


### PR DESCRIPTION
* Added model `sat_workflow_run_detail`. The workflow run record source is
  coming from Workflow Manager. Detail has been flattened from child dependant
  tables as we would like to query them together when looking at satellite history
  detail table. Therefore, it uses table name as prefix naming convention.
* Added model `sat_workflow_run_comment` table to track separately about comments.
  Reason being workflow run comment has different dimensional concern and rate of change.
