### PR TITLE
Improved sat_s3object_filemanager satellite

### DIFF
--- a/orcavault/models/dcl/sat_s3object_filemanager.sql
+++ b/orcavault/models/dcl/sat_s3object_filemanager.sql
@@ -9,8 +9,7 @@
 with source as (
 
     select
-        *,
-        row_number() over (partition by bucket, key, cast(event_time as date) order by cast(event_time as date) desc, is_current_state desc) as rank
+        *
     from
         {{ source('ods', 'file_manager_s3_object') }}
     {% if is_incremental() %}
@@ -24,36 +23,28 @@ transformed as (
 
     select
         encode(sha256(concat(bucket, "key")::bytea), 'hex') as s3object_hk,
-        cast(event_time as timestamptz) as load_datetime,
+        cast('{{ run_started_at }}' as timestamptz) as load_datetime,
         (select 'file_manager_s3_object') as record_source,
         encode(sha256(concat(
             s3_object_id,
             "size",
             e_tag,
-            last_modified_date,
             sha256,
-            event_type,
+            last_modified_date,
             event_time,
+            event_type,
             version_id,
-            storage_class,
-            sequencer,
             is_delete_marker,
-            number_duplicate_events,
+            sequencer,
+            storage_class,
             attributes,
-            deleted_date,
-            deleted_sequencer,
-            number_reordered,
             ingest_id,
-            is_current_state,
             reason,
-            archive_status,
-            is_accessible
+            archive_status
         )::bytea), 'hex') as hash_diff,
         *
     from
         source
-    where
-        rank = 1
 
 ),
 
@@ -61,30 +52,25 @@ final as (
 
     select
         cast(s3object_hk as char(64)) as s3object_hk,
+        cast(hash_diff as char(64)) as s3object_sq,
         cast(load_datetime as timestamptz) as load_datetime,
         cast(record_source as varchar(255)) as record_source,
         cast(hash_diff as char(64)) as hash_diff,
         cast(s3_object_id as uuid) as s3_object_id,
         cast("size" as bigint) as "size",
         cast(e_tag as varchar(255)) as e_tag,
-        cast(last_modified_date as timestamptz) as last_modified_date,
         cast(sha256 as text) as sha256,
-        cast(event_type as varchar(255)) as event_type,
+        cast(last_modified_date as timestamptz) as last_modified_date,
         cast(event_time as timestamptz) as event_time,
+        cast(event_type as varchar(255)) as event_type,
         cast(version_id as varchar(255)) as version_id,
-        cast(storage_class as varchar(255)) as storage_class,
-        cast(sequencer as varchar(255)) as sequencer,
         cast(is_delete_marker as boolean) as is_delete_marker,
-        cast(number_duplicate_events as bigint) as number_duplicate_events,
+        cast(sequencer as varchar(255)) as sequencer,
+        cast(storage_class as varchar(255)) as storage_class,
         cast(attributes as jsonb) as attributes,
-        cast(deleted_date as timestamptz) as deleted_date,
-        cast(deleted_sequencer as varchar(255)) as deleted_sequencer,
-        cast(number_reordered as varchar(255)) as number_reordered,
         cast(ingest_id as uuid) as ingest_id,
-        cast(is_current_state as boolean) as is_current_state,
         cast(reason as varchar(255)) as reason,
-        cast(archive_status as varchar(255)) as archive_status,
-        cast(is_accessible as boolean) as is_accessible
+        cast(archive_status as varchar(255)) as archive_status
     from
         transformed
 

--- a/orcavault/models/dcl/sat_schema.yml
+++ b/orcavault/models/dcl/sat_schema.yml
@@ -379,13 +379,15 @@ models:
       contract: { enforced: true }
     constraints:
       - type: primary_key
-        columns: [ s3object_hk, load_datetime ]
+        columns: [ s3object_hk, s3object_sq, load_datetime ]
       - type: foreign_key
         columns: [ s3object_hk ]
         to: ref('hub_s3object')
         to_columns: [ s3object_hk ]
     columns:
       - name: s3object_hk
+        data_type: char(64)
+      - name: s3object_sq
         data_type: char(64)
       - name: load_datetime
         data_type: timestamptz
@@ -399,42 +401,30 @@ models:
         data_type: bigint
       - name: e_tag
         data_type: varchar(255)
-      - name: last_modified_date
-        data_type: timestamptz
       - name: sha256
         data_type: text
-      - name: event_type
-        data_type: varchar(255)
+      - name: last_modified_date
+        data_type: timestamptz
       - name: event_time
         data_type: timestamptz
+      - name: event_type
+        data_type: varchar(255)
       - name: version_id
-        data_type: varchar(255)
-      - name: storage_class
-        data_type: varchar(255)
-      - name: sequencer
         data_type: varchar(255)
       - name: is_delete_marker
         data_type: boolean
-      - name: number_duplicate_events
-        data_type: bigint
+      - name: sequencer
+        data_type: varchar(255)
+      - name: storage_class
+        data_type: varchar(255)
       - name: attributes
         data_type: jsonb
-      - name: deleted_date
-        data_type: timestamptz
-      - name: deleted_sequencer
-        data_type: varchar(255)
-      - name: number_reordered
-        data_type: varchar(255)
       - name: ingest_id
         data_type: uuid
-      - name: is_current_state
-        data_type: boolean
       - name: reason
         data_type: varchar(255)
       - name: archive_status
         data_type: varchar(255)
-      - name: is_accessible
-        data_type: boolean
 
   - name: sat_workflow_run_portal
     config:


### PR DESCRIPTION
* Retained S3 event message columns and dropped FileManager internal logic columns
* Improved incremental loading now solely depends on event_time to load
  history records delta
* Improved better system generated load_datetime
* Improved into Multi-Active Satellite (MAS) pattern by leveraging hash_diff
  as sequence number in composite PK
