### PR TITLE
Refactored and fixed Google Spreadsheet extract step via csv

### DIFF
--- a/infra/glue/requirements.txt
+++ b/infra/glue/requirements.txt
@@ -1,5 +1,5 @@
 libumccr==0.4.1
-google-auth==2.37.0
+google-auth==2.38.0
 requests==2.32.3
-polars==1.19.0
-fastexcel==0.12.0
+polars==1.26.0
+gspread==6.2.0

--- a/infra/glue/workspace/spreadsheet_library_tracking_metadata/spreadsheet_library_tracking_metadata.py
+++ b/infra/glue/workspace/spreadsheet_library_tracking_metadata/spreadsheet_library_tracking_metadata.py
@@ -1,14 +1,13 @@
+import csv
 import json
 import os
 import sys
 
+import gspread
 import polars as pl
-import requests
 from awsglue.context import GlueContext
 from awsglue.job import Job
 from awsglue.utils import getResolvedOptions
-from google.auth.transport.requests import Request
-from google.oauth2.service_account import Credentials
 from libumccr.aws import libssm, libsm, libs3
 from pyspark.sql import SparkSession
 
@@ -39,21 +38,16 @@ REGION_NAME = "ap-southeast-2"
 def extract():
     spreadsheet_id = libssm.get_secret(TRACKING_SHEET_ID)
     account_info = libssm.get_secret(GDRIVE_SERVICE_ACCOUNT)
-    credentials: Credentials = Credentials.from_service_account_info(json.loads(account_info), scopes=SCOPES)
-    credentials.refresh(Request())
 
-    export_url = f"https://www.googleapis.com/drive/v3/files/{spreadsheet_id}/export?mimeType=application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    gs = gspread.service_account_from_dict(json.loads(account_info))
+    sh = gs.open_by_key(spreadsheet_id)
 
-    headers = {
-        'Authorization': f'Bearer {credentials.token}',
-    }
-
-    response = requests.get(export_url, headers=headers)
-    if response.status_code == 200:
-        with open(f"{OUT_PATH}.xlsx", 'wb') as file:
-            file.write(response.content)
-    else:
-        raise Exception(f"Failed to download spreadsheet: {response.status_code} - {response.text}")
+    for sheet in SHEETS:
+        worksheet = sh.worksheet(sheet)
+        filename = f"{OUT_PATH}__{sheet}.csv"
+        with open(filename, 'w') as f:
+            writer = csv.writer(f)
+            writer.writerows(worksheet.get_all_values())
 
 
 def transform():
@@ -65,7 +59,7 @@ def transform():
         # treat all columns as string value, do not automatically infer the dataframe dtype i.e. infer_schema_length=0
         # https://github.com/pola-rs/polars/pull/16840
         # https://stackoverflow.com/questions/77318631/how-to-read-all-columns-as-strings-in-polars
-        df = pl.read_excel(f"{OUT_PATH}.xlsx", sheet_name=sheet, infer_schema_length=0)
+        df = pl.read_csv(f"{OUT_PATH}__{sheet}.csv", infer_schema_length=False, infer_schema=False)
 
         # handle sheet specific cases
         match sheet:
@@ -132,11 +126,17 @@ def transform():
         for col in df.columns:
             if col.startswith('__UNNAMED__'):
                 df = df.drop(col)
+            if col.startswith('_duplicated'):
+                df = df.drop(col)
+            if col == '':
+                df = df.drop(col)
 
         # add sheet name as a column
         df = df.with_columns(pl.lit(sheet).alias('sheet_name'))
 
         row_count += df.shape[0]
+
+        print(sheet, df.columns)
 
         frames.append(df)
 
@@ -201,13 +201,12 @@ def transform():
 
 def load(spark: SparkSession):
     # load staging data from the temporary location by naming convention
-    csv_file, sql_file, xls_file = f"{OUT_PATH}.csv", f"{OUT_PATH}.sql", f"{OUT_PATH}.xlsx"
+    csv_file, sql_file = f"{OUT_PATH}.csv", f"{OUT_PATH}.sql"
 
     # construct s3 object name
 
     csv_s3_object_name = f"{S3_MID_PATH}/{os.path.basename(csv_file)}"
     sql_s3_object_name = f"{S3_MID_PATH}/{os.path.basename(sql_file)}"
-    xls_s3_object_name = f"{S3_MID_PATH}/{os.path.basename(xls_file)}"
 
     # load data into S3
 
@@ -215,7 +214,6 @@ def load(spark: SparkSession):
 
     s3_client.upload_file(csv_file, S3_BUCKET, csv_s3_object_name)
     s3_client.upload_file(sql_file, S3_BUCKET, sql_s3_object_name)
-    s3_client.upload_file(xls_file, S3_BUCKET, xls_s3_object_name)
 
     # load data into database
 


### PR DESCRIPTION
* Previously we extract Google Spreadsheet export as Excel format. This, however,
  failed on parsing RichText formated cell values.
  e.g. Value `4416-1` get exported as date format cell as in `4416-01-01 00:00:00`
* Fixed by refactored to use gspread SDK to download and extract value as PlainText
* Bumped Glue job Python script dependencies
