### PR TITLE
Improved Link model between Library and InternalSubject

### DIFF
--- a/orcavault/models/dcl/link_library_internal_subject.sql
+++ b/orcavault/models/dcl/link_library_internal_subject.sql
@@ -13,11 +13,6 @@ with source as (
     union
     select library_id, subject_id as internal_subject_id from {{ source('ods', 'data_portal_limsrow') }}
     union
-    select lib.library_id as library_id, idv.individual_id as internal_subject_id from {{ source('ods', 'metadata_manager_library') }} as lib
-        join {{ source('ods', 'metadata_manager_subject') }} as sbj on sbj.orcabus_id = lib.subject_orcabus_id
-        join {{ source('ods', 'metadata_manager_subjectindividuallink') }} as lnk on lnk.subject_orcabus_id = sbj.orcabus_id
-        join {{ source('ods', 'metadata_manager_individual') }} as idv on idv.orcabus_id = lnk.individual_orcabus_id
-    union
     select library_id, subject_id as internal_subject_id from {{ ref('spreadsheet_library_tracking_metadata') }}
     union
     select library_id, subject_id as internal_subject_id from {{ ref('spreadsheet_google_lims') }}


### PR DESCRIPTION
* Removed link source from MetadataManager as there exist no direct link concept
  between Library to InternalSubject. But only via ExternalSubject. Previous
  attempt sourcing by table join call (removing code in this PR) creates cartesian
  product of two outer sets; which is counterproductive.
* In warehouse Raw Vault modelling world, this phenomenon is designed by isolating
  side channel linking concept i.e. when in need on demands, there exists dedicated
  InternalSubject to ExternalSubject link; at the same time, maintaining direct link
  from Library to InternalSubject or ExternalSubject.
* The same principal apply to Libray Ownership concept modelling. See #66
