### PR TITLE
Refactored hub_s3object computed satellite

### DIFF
--- a/orcavault/models/dcl/sat_s3object_by_library.sql
+++ b/orcavault/models/dcl/sat_s3object_by_library.sql
@@ -1,0 +1,74 @@
+{{
+    config(
+        indexes=[
+            {'columns': ['library_id'], 'type': 'btree'},
+            {'columns': ['library_id', 'ext1', 'ext2'], 'type': 'btree'},
+            {'columns': ['ext1'], 'type': 'btree'},
+            {'columns': ['ext2'], 'type': 'btree'},
+            {'columns': ['ext1', 'ext2'], 'type': 'btree'},
+            {'columns': ['filename'], 'type': 'btree'},
+            {'columns': ['hash_diff'], 'type': 'btree'},
+        ],
+        materialized='incremental',
+        incremental_strategy='append',
+        on_schema_change='fail'
+    )
+}}
+
+with source as (
+
+    select
+        s3object_hk,
+        (regexp_matches("key", '(?:L\d{7}|L(?:PRJ|CCR|MDX|TGX)\d{6}|Undetermined)(?:(?:_topup\d?)|(?:_rerun\d?))?', 'g'))[1] as library_id,
+        regexp_replace("key", '^.+[/\\]', '') as filename,
+        split_part(regexp_replace("key", '^.+[/\\]', ''), '.', -1) as ext1,
+        split_part(regexp_replace("key", '^.+[/\\]', ''), '.', -2) as ext2,
+        split_part(regexp_replace("key", '^.+[/\\]', ''), '.', -3) as ext3,
+        load_datetime,
+        record_source
+    from
+        {{ ref('hub_s3object') }}
+    {% if is_incremental() %}
+    where
+        cast(load_datetime as timestamptz) > ( select coalesce(max(load_datetime), '1900-01-01') as ldts from {{ this }} )
+    {% endif %}
+    group by s3object_hk, library_id
+
+),
+
+transformed as (
+
+    select
+        s3object_hk,
+        cast('{{ run_started_at }}' as timestamptz) as load_datetime,
+        record_source,
+        encode(sha256(concat(s3object_hk, library_id)::bytea), 'hex') as hash_diff,
+        library_id,
+        filename,
+        ext1,
+        ext2,
+        ext3
+    from
+        source
+
+),
+
+final as (
+
+    select
+        cast(s3object_hk as char(64)) as s3object_hk,
+        cast(hash_diff as char(64)) as s3object_sq,
+        cast(load_datetime as timestamptz) as load_datetime,
+        cast(record_source as varchar(255)) as record_source,
+        cast(hash_diff as char(64)) as hash_diff,
+        cast(library_id as varchar(255)) as library_id,
+        cast(filename as text) as filename,
+        cast(ext1 as varchar(255)) as ext1,
+        cast(ext2 as varchar(255)) as ext2,
+        cast(ext3 as varchar(255)) as ext3
+    from
+        transformed
+
+)
+
+select * from final

--- a/orcavault/models/dcl/sat_s3object_by_run.sql
+++ b/orcavault/models/dcl/sat_s3object_by_run.sql
@@ -3,9 +3,8 @@
         indexes=[
             {'columns': ['portal_run_id'], 'type': 'btree'},
             {'columns': ['sequencing_run_id'], 'type': 'btree'},
-            {'columns': ['library_id'], 'type': 'btree'},
-            {'columns': ['sequencing_run_id', 'library_id'], 'type': 'btree'},
-            {'columns': ['sequencing_run_id', 'library_id', 'ext1', 'ext2'], 'type': 'btree'},
+            {'columns': ['sequencing_run_id', 'portal_run_id'], 'type': 'btree'},
+            {'columns': ['sequencing_run_id', 'portal_run_id', 'ext1', 'ext2'], 'type': 'btree'},
             {'columns': ['ext1'], 'type': 'btree'},
             {'columns': ['ext2'], 'type': 'btree'},
             {'columns': ['ext1', 'ext2'], 'type': 'btree'},
@@ -24,7 +23,6 @@ with source as (
         s3object_hk,
         (regexp_match("key", '(?:/)(\d{8}[a-zA-Z0-9]{8})(?:/)'))[1] as portal_run_id,
         (regexp_match("key", '(?:/)(\d{6}_A\d{5}_\d{4}_[A-Z0-9]{10})(?:/)'))[1] as sequencing_run_id,
-        (regexp_matches("key", '(?:L\d{7}|L(?:PRJ|CCR|MDX|TGX)\d{6}|Undetermined)(?:(?:_topup\d?)|(?:_rerun\d?))?', 'g'))[1] as library_id,
         regexp_replace("key", '^.+[/\\]', '') as filename,
         split_part(regexp_replace("key", '^.+[/\\]', ''), '.', -1) as ext1,
         split_part(regexp_replace("key", '^.+[/\\]', ''), '.', -2) as ext2,
@@ -37,7 +35,7 @@ with source as (
     where
         cast(load_datetime as timestamptz) > ( select coalesce(max(load_datetime), '1900-01-01') as ldts from {{ this }} )
     {% endif %}
-    group by s3object_hk, portal_run_id, sequencing_run_id, library_id
+    group by s3object_hk, portal_run_id, sequencing_run_id
 
 ),
 
@@ -47,10 +45,9 @@ transformed as (
         s3object_hk,
         cast('{{ run_started_at }}' as timestamptz) as load_datetime,
         record_source,
-        encode(sha256(concat(s3object_hk, portal_run_id, sequencing_run_id, library_id)::bytea), 'hex') as hash_diff,
+        encode(sha256(concat(s3object_hk, portal_run_id, sequencing_run_id)::bytea), 'hex') as hash_diff,
         portal_run_id,
         sequencing_run_id,
-        library_id,
         filename,
         ext1,
         ext2,
@@ -70,7 +67,6 @@ final as (
         cast(hash_diff as char(64)) as hash_diff,
         cast(portal_run_id as char(16)) as portal_run_id,
         cast(sequencing_run_id as varchar(255)) as sequencing_run_id,
-        cast(library_id as varchar(255)) as library_id,
         cast(filename as text) as filename,
         cast(ext1 as varchar(255)) as ext1,
         cast(ext2 as varchar(255)) as ext2,

--- a/orcavault/models/dcl/sat_schema.yml
+++ b/orcavault/models/dcl/sat_schema.yml
@@ -608,7 +608,7 @@ models:
       - name: is_deleted
         data_type: boolean
 
-  - name: sat_s3object_computed_key
+  - name: sat_s3object_by_run
     config:
       contract: { enforced: true }
     constraints:
@@ -633,6 +633,36 @@ models:
         data_type: char(16)
       - name: sequencing_run_id
         data_type: varchar(255)
+      - name: filename
+        data_type: text
+      - name: ext1
+        data_type: varchar(255)
+      - name: ext2
+        data_type: varchar(255)
+      - name: ext3
+        data_type: varchar(255)
+
+  - name: sat_s3object_by_library
+    config:
+      contract: { enforced: true }
+    constraints:
+      - type: primary_key
+        columns: [ s3object_hk, s3object_sq, load_datetime ]
+      - type: foreign_key
+        columns: [ s3object_hk ]
+        to: ref('hub_s3object')
+        to_columns: [ s3object_hk ]
+    columns:
+      - name: s3object_hk
+        data_type: char(64)
+      - name: s3object_sq
+        data_type: char(64)
+      - name: load_datetime
+        data_type: timestamptz
+      - name: record_source
+        data_type: varchar(255)
+      - name: hash_diff
+        data_type: char(64)
       - name: library_id
         data_type: varchar(255)
       - name: filename


### PR DESCRIPTION
* Basically these are pre-built index table for well-known business keys
  from hub_s3object key path to create two computed satellites. Mainly for
  query performance. Better split into two satellites because the rate of
  change is differing between RunID vs LibraryID business keys. Typically,
  user query is also mutually exclusive between the two use cases as well.
* By splitting into two tables, it is also achieving maximum regexp extraction
  coverage and, maintain index table size to the lowest possible.
