### PR TITLE
Implemented data marts for warehouse Beta Demo

### DIFF
--- a/orcavault/dbt_project.yml
+++ b/orcavault/dbt_project.yml
@@ -24,3 +24,6 @@ models:
     dcl:
       +schema: dcl
       +materialized: table
+    mart:
+      +schema: mart
+      +materialized: table

--- a/orcavault/models/mart/centre/_schema.yml
+++ b/orcavault/models/mart/centre/_schema.yml
@@ -1,0 +1,9 @@
+version: 2
+
+models:
+
+  - name: lims
+    description: Listing of Centre genomic sequencing LIMS metadata in flat table model
+
+  - name: fastq
+    description: Listing of Centre genomic sequencing unaligned read level FASTQ S3 locations in flat table model

--- a/orcavault/models/mart/centre/fastq.sql
+++ b/orcavault/models/mart/centre/fastq.sql
@@ -1,0 +1,67 @@
+{{
+    config(
+        indexes=[
+            {'columns': ['sequencing_run_id'], 'type': 'btree'},
+            {'columns': ['sequencing_run_date'], 'type': 'btree'},
+            {'columns': ['portal_run_id'], 'type': 'btree'},
+            {'columns': ['library_id'], 'type': 'btree'},
+            {'columns': ['sequencing_run_id', 'library_id'], 'type': 'btree'},
+            {'columns': ['bucket'], 'type': 'btree'},
+            {'columns': ['key'], 'type': 'btree'},
+            {'columns': ['filename'], 'type': 'btree'},
+            {'columns': ['format'], 'type': 'btree'},
+            {'columns': ['size'], 'type': 'btree'},
+            {'columns': ['storage_class'], 'type': 'btree'},
+            {'columns': ['last_modified_date'], 'type': 'btree'},
+        ]
+    )
+}}
+
+with transformed as (
+
+    select
+        sat.sequencing_run_id as sequencing_run_id,
+        cast((regexp_match(sat.sequencing_run_id, '(?:^)(\d{6})(?:_A\d{5}_\d{4}_[A-Z0-9]{10})'))[1] as date) as sequencing_run_date,
+        sat.portal_run_id as portal_run_id,
+        hub.bucket as bucket,
+        hub.key as "key",
+        (regexp_match(sat.filename, '(?:L\d{7}|L(?:PRJ|CCR|MDX|TGX)\d{6}|Undetermined)(?:(?:_topup\d?)|(?:_rerun\d?))?'))[1] as library_id,
+        sat.filename as filename,
+        sat.ext1 as format,
+        cur.size as "size",
+        cur.storage_class as storage_class,
+        cur.e_tag as e_tag,
+        cur.last_modified_date as last_modified_date
+    from {{ ref('hub_s3object') }} hub
+        join {{ ref('sat_s3object_by_run') }} sat on sat.s3object_hk = hub.s3object_hk
+        join {{ ref('sat_s3object_current') }} cur on cur.s3object_hk = hub.s3object_hk
+    where
+        (sat.ext1 = 'gz' or sat.ext1 = 'ora')
+        and sat.ext2 = 'fastq'
+        and cur.is_current = 1
+        and cur.is_deleted = 0
+
+),
+
+final as (
+
+    select
+        cast(sequencing_run_id as varchar(255)) as sequencing_run_id,
+        cast(sequencing_run_date as date) as sequencing_run_date,
+        cast(portal_run_id as varchar(255)) as portal_run_id,
+        cast(bucket as varchar(255)) as bucket,
+        cast("key" as text) as "key",
+        cast(library_id as varchar(255)) as library_id,
+        cast(filename as text) as filename,
+        cast(format as varchar(255)) as format,
+        cast("size" as bigint) as "size",
+        cast(storage_class as varchar(255)) as storage_class,
+        cast(e_tag as varchar(255)) as e_tag,
+        cast(last_modified_date as timestamptz) as last_modified_date
+    from
+        transformed
+    order by sequencing_run_date desc nulls last, library_id desc
+
+)
+
+select * from final

--- a/orcavault/models/mart/centre/lims.sql
+++ b/orcavault/models/mart/centre/lims.sql
@@ -1,0 +1,109 @@
+{{
+    config(
+        indexes=[
+            {'columns': ['sequencing_run_id'], 'type': 'btree'},
+            {'columns': ['sequencing_run_date'], 'type': 'btree'},
+            {'columns': ['library_id'], 'type': 'btree'},
+            {'columns': ['internal_subject_id'], 'type': 'btree'},
+            {'columns': ['external_subject_id'], 'type': 'btree'},
+            {'columns': ['sample_id'], 'type': 'btree'},
+            {'columns': ['external_sample_id'], 'type': 'btree'},
+            {'columns': ['experiment_id'], 'type': 'btree'},
+            {'columns': ['project_id'], 'type': 'btree'},
+            {'columns': ['owner_id'], 'type': 'btree'},
+            {'columns': ['workflow'], 'type': 'btree'},
+            {'columns': ['phenotype'], 'type': 'btree'},
+            {'columns': ['type'], 'type': 'btree'},
+            {'columns': ['assay'], 'type': 'btree'},
+            {'columns': ['quality'], 'type': 'btree'},
+            {'columns': ['source'], 'type': 'btree'},
+            {'columns': ['load_datetime'], 'type': 'btree'},
+        ]
+    )
+}}
+
+with transformed as (
+
+    select
+
+        sqr.sequencing_run_id as sequencing_run_id,
+        cast((regexp_match(sqr.sequencing_run_id, '(?:^)(\d{6})(?:_A\d{5}_\d{4}_[A-Z0-9]{10})'))[1] as date) as sequencing_run_date,
+        lib.library_id as library_id,
+        int_sbj.internal_subject_id as internal_subject_id,
+        ext_sbj.external_subject_id as external_subject_id,
+        smp.sample_id as sample_id,
+        ext_smp.external_sample_id as external_sample_id,
+        expr.experiment_id as experiment_id,
+        prj.project_id as project_id,
+        owner.owner_id as owner_id,
+        sat.workflow as workflow,
+        sat.phenotype as phenotype,
+        sat.type as type,
+        sat.assay as assay,
+        sat.quality as quality,
+        sat.source as source,
+        sat.truseq_index as truseq_index,
+        sat.load_datetime as load_datetime
+
+    from
+
+        {{ ref('hub_library') }} lib
+
+            left join {{ ref('link_library_sequencing_run') }} lnk1 on lib.library_hk = lnk1.library_hk
+            left join {{ ref('hub_sequencing_run') }} sqr on lnk1.sequencing_run_hk = sqr.sequencing_run_hk
+
+            left join {{ ref('link_library_internal_subject') }} lnk2 on lib.library_hk = lnk2.library_hk
+            left join {{ ref('hub_internal_subject') }} int_sbj on lnk2.internal_subject_hk = int_sbj.internal_subject_hk
+
+            left join {{ ref('link_library_external_subject') }} lnk3 on lib.library_hk = lnk3.library_hk
+            left join {{ ref('hub_external_subject') }} ext_sbj on lnk3.external_subject_hk = ext_sbj.external_subject_hk
+
+            left join {{ ref('link_library_sample') }} lnk4 on lib.library_hk = lnk4.library_hk
+            left join {{ ref('hub_sample') }} smp on lnk4.sample_hk = smp.sample_hk
+
+            left join {{ ref('link_library_external_sample') }} lnk5 on lib.library_hk = lnk5.library_hk
+            left join {{ ref('hub_external_sample') }} ext_smp on lnk5.external_sample_hk = ext_smp.external_sample_hk
+
+            left join {{ ref('link_library_experiment') }} lnk6 on lib.library_hk = lnk6.library_hk
+            left join {{ ref('hub_experiment') }} expr on lnk6.experiment_hk = expr.experiment_hk
+
+            left join {{ ref('link_library_project') }} lnk7 on lib.library_hk = lnk7.library_hk
+            left join {{ ref('hub_project') }} prj on lnk7.project_hk = prj.project_hk
+
+            left join {{ ref('link_library_ownership') }} lnk8 on lib.library_hk = lnk8.library_hk
+            left join {{ ref('hub_owner') }} owner on lnk8.owner_hk = owner.owner_hk
+
+            left join {{ ref('sat_library_glab') }} sat on lib.library_hk = sat.library_hk
+
+),
+
+final as (
+
+    select
+        cast(sequencing_run_id as varchar(255)) as sequencing_run_id,
+        cast(sequencing_run_date as date) as sequencing_run_date,
+        cast(library_id as varchar(255)) as library_id,
+        cast(internal_subject_id as varchar(255)) as internal_subject_id,
+        cast(external_subject_id as varchar(255)) as external_subject_id,
+        cast(sample_id as varchar(255)) as sample_id,
+        cast(external_sample_id as varchar(255)) as external_sample_id,
+        cast(experiment_id as varchar(255)) as experiment_id,
+        cast(project_id as varchar(255)) as project_id,
+        cast(owner_id as varchar(255)) as owner_id,
+        cast(workflow as varchar(255)) as workflow,
+        cast(phenotype as varchar(255)) as phenotype,
+        cast(type as varchar(255)) as type,
+        cast(assay as varchar(255)) as assay,
+        cast(quality as varchar(255)) as quality,
+        cast(source as varchar(255)) as source,
+        cast(truseq_index as varchar(255)) as truseq_index,
+        cast(load_datetime as timestamptz) as load_datetime
+    from
+        transformed
+    where
+        sequencing_run_id is not null
+    order by sequencing_run_date desc nulls last, library_id desc
+
+)
+
+select * from final

--- a/orcavault/models/mart/curation/_schema.yml
+++ b/orcavault/models/mart/curation/_schema.yml
@@ -1,0 +1,6 @@
+version: 2
+
+models:
+
+  - name: curation_lims
+    description: Listing of Centre Curation Team LIMS metadata in flat table model

--- a/orcavault/models/mart/curation/curation_lims.sql
+++ b/orcavault/models/mart/curation/curation_lims.sql
@@ -1,0 +1,68 @@
+{{
+    config(
+        indexes=[
+            {'columns': ['sequencing_run_id'], 'type': 'btree'},
+            {'columns': ['sequencing_run_date'], 'type': 'btree'},
+            {'columns': ['library_id'], 'type': 'btree'},
+            {'columns': ['internal_subject_id'], 'type': 'btree'},
+            {'columns': ['external_subject_id'], 'type': 'btree'},
+            {'columns': ['sample_id'], 'type': 'btree'},
+            {'columns': ['external_sample_id'], 'type': 'btree'},
+            {'columns': ['experiment_id'], 'type': 'btree'},
+            {'columns': ['project_id'], 'type': 'btree'},
+            {'columns': ['owner_id'], 'type': 'btree'},
+            {'columns': ['workflow'], 'type': 'btree'},
+            {'columns': ['phenotype'], 'type': 'btree'},
+            {'columns': ['type'], 'type': 'btree'},
+            {'columns': ['assay'], 'type': 'btree'},
+            {'columns': ['quality'], 'type': 'btree'},
+            {'columns': ['source'], 'type': 'btree'},
+            {'columns': ['load_datetime'], 'type': 'btree'},
+        ]
+    )
+}}
+
+with transformed as (
+
+    select
+        *
+    from
+        {{ ref('lims') }}
+    where
+        sequencing_run_id is not null
+        and type is not null
+        and type not in ('10X', 'BiModal', 'exome', 'Exome', 'MeDIP', 'Metagenm', 'MethylSeq')
+        and assay is not null
+        and assay not like '%10X%'
+        and assay not in ('BM-5L', 'BM-6L', 'CRISPR', 'MeDIP', 'Takara')
+        and workflow in ('research', 'clinical', 'control', 'manual')
+),
+
+final as (
+
+    select
+        cast(sequencing_run_id as varchar(255)) as sequencing_run_id,
+        cast(sequencing_run_date as date) as sequencing_run_date,
+        cast(library_id as varchar(255)) as library_id,
+        cast(internal_subject_id as varchar(255)) as internal_subject_id,
+        cast(external_subject_id as varchar(255)) as external_subject_id,
+        cast(sample_id as varchar(255)) as sample_id,
+        cast(external_sample_id as varchar(255)) as external_sample_id,
+        cast(experiment_id as varchar(255)) as experiment_id,
+        cast(project_id as varchar(255)) as project_id,
+        cast(owner_id as varchar(255)) as owner_id,
+        cast(workflow as varchar(255)) as workflow,
+        cast(phenotype as varchar(255)) as phenotype,
+        cast(type as varchar(255)) as type,
+        cast(assay as varchar(255)) as assay,
+        cast(quality as varchar(255)) as quality,
+        cast(source as varchar(255)) as source,
+        cast(truseq_index as varchar(255)) as truseq_index,
+        cast(load_datetime as timestamptz) as load_datetime
+    from
+        transformed
+    order by sequencing_run_date desc nulls last, library_id desc
+
+)
+
+select * from final

--- a/orcavault/models/mart/dawson/_schema.yml
+++ b/orcavault/models/mart/dawson/_schema.yml
@@ -1,0 +1,9 @@
+version: 2
+
+models:
+
+  - name: dawson_lims
+    description: Listing of Dawson Research Group LIMS metadata in flat table model
+
+  - name: dawson_fastq
+    description: Listing of Dawson Research Group primary read level FASTQ S3 locations in flat table model

--- a/orcavault/models/mart/dawson/dawson_fastq.sql
+++ b/orcavault/models/mart/dawson/dawson_fastq.sql
@@ -1,0 +1,60 @@
+{{
+    config(
+        indexes=[
+            {'columns': ['sequencing_run_id'], 'type': 'btree'},
+            {'columns': ['sequencing_run_date'], 'type': 'btree'},
+            {'columns': ['portal_run_id'], 'type': 'btree'},
+            {'columns': ['library_id'], 'type': 'btree'},
+            {'columns': ['bucket'], 'type': 'btree'},
+            {'columns': ['key'], 'type': 'btree'},
+            {'columns': ['filename'], 'type': 'btree'},
+            {'columns': ['format'], 'type': 'btree'},
+            {'columns': ['size'], 'type': 'btree'},
+            {'columns': ['storage_class'], 'type': 'btree'},
+            {'columns': ['last_modified_date'], 'type': 'btree'},
+        ]
+    )
+}}
+
+with transformed as (
+
+    select
+        lims.sequencing_run_id as sequencing_run_id,
+        fq.sequencing_run_date as sequencing_run_date,
+        fq.portal_run_id,
+        fq.bucket as bucket,
+        fq.key as "key",
+        lims.library_id as library_id,
+        fq.filename as filename,
+        fq.format as format,
+        fq.size as "size",
+        fq.storage_class as storage_class,
+        fq.e_tag as e_tag,
+        fq.last_modified_date as last_modified_date
+    from {{ ref('fastq') }} fq
+        join {{ ref('dawson_lims') }} lims on lims.library_id = fq.library_id and lims.sequencing_run_id = fq.sequencing_run_id
+
+),
+
+final as (
+
+    select
+        cast(sequencing_run_id as varchar(255)) as sequencing_run_id,
+        cast(sequencing_run_date as date) as sequencing_run_date,
+        cast(portal_run_id as varchar(255)) as portal_run_id,
+        cast(bucket as varchar(255)) as bucket,
+        cast("key" as text) as "key",
+        cast(library_id as varchar(255)) as library_id,
+        cast(filename as text) as filename,
+        cast(format as varchar(255)) as format,
+        cast("size" as bigint) as "size",
+        cast(storage_class as varchar(255)) as storage_class,
+        cast(e_tag as varchar(255)) as e_tag,
+        cast(last_modified_date as timestamptz) as last_modified_date
+    from
+        transformed
+    order by sequencing_run_date desc nulls last, library_id desc
+
+)
+
+select * from final

--- a/orcavault/models/mart/dawson/dawson_lims.sql
+++ b/orcavault/models/mart/dawson/dawson_lims.sql
@@ -1,0 +1,73 @@
+{{
+    config(
+        indexes=[
+            {'columns': ['sequencing_run_id'], 'type': 'btree'},
+            {'columns': ['sequencing_run_date'], 'type': 'btree'},
+            {'columns': ['library_id'], 'type': 'btree'},
+            {'columns': ['internal_subject_id'], 'type': 'btree'},
+            {'columns': ['external_subject_id'], 'type': 'btree'},
+            {'columns': ['sample_id'], 'type': 'btree'},
+            {'columns': ['external_sample_id'], 'type': 'btree'},
+            {'columns': ['experiment_id'], 'type': 'btree'},
+            {'columns': ['project_id'], 'type': 'btree'},
+            {'columns': ['owner_id'], 'type': 'btree'},
+            {'columns': ['workflow'], 'type': 'btree'},
+            {'columns': ['phenotype'], 'type': 'btree'},
+            {'columns': ['type'], 'type': 'btree'},
+            {'columns': ['assay'], 'type': 'btree'},
+            {'columns': ['quality'], 'type': 'btree'},
+            {'columns': ['source'], 'type': 'btree'},
+            {'columns': ['load_datetime'], 'type': 'btree'},
+        ]
+    )
+}}
+
+with transformed as (
+
+    select
+        *
+    from
+        {{ ref('lims') }}
+    where
+        owner_id = 'Dawson'
+        and project_id in (
+            select
+                distinct prj.project_id
+            from
+                {{ ref('hub_project') }} prj
+                    join {{ ref('link_project_ownership') }} lnk on prj.project_hk = lnk.project_hk
+                    join {{ ref('hub_owner') }} owner on lnk.owner_hk = owner.owner_hk
+            where
+                owner.owner_id = 'Dawson'
+        )
+
+),
+
+final as (
+
+    select
+        cast(sequencing_run_id as varchar(255)) as sequencing_run_id,
+        cast(sequencing_run_date as date) as sequencing_run_date,
+        cast(library_id as varchar(255)) as library_id,
+        cast(internal_subject_id as varchar(255)) as internal_subject_id,
+        cast(external_subject_id as varchar(255)) as external_subject_id,
+        cast(sample_id as varchar(255)) as sample_id,
+        cast(external_sample_id as varchar(255)) as external_sample_id,
+        cast(experiment_id as varchar(255)) as experiment_id,
+        cast(project_id as varchar(255)) as project_id,
+        cast(owner_id as varchar(255)) as owner_id,
+        cast(workflow as varchar(255)) as workflow,
+        cast(phenotype as varchar(255)) as phenotype,
+        cast(type as varchar(255)) as type,
+        cast(assay as varchar(255)) as assay,
+        cast(quality as varchar(255)) as quality,
+        cast(source as varchar(255)) as source,
+        cast(truseq_index as varchar(255)) as truseq_index,
+        cast(load_datetime as timestamptz) as load_datetime
+    from
+        transformed
+    order by sequencing_run_date desc nulls last, library_id desc
+
+)
+
+select * from final

--- a/orcavault/models/mart/grimmond/_schema.yml
+++ b/orcavault/models/mart/grimmond/_schema.yml
@@ -1,0 +1,6 @@
+version: 2
+
+models:
+
+  - name: grimmond_lims
+    description: Listing of Grimmond Research Group LIMS metadata in flat table model

--- a/orcavault/models/mart/grimmond/grimmond_lims.sql
+++ b/orcavault/models/mart/grimmond/grimmond_lims.sql
@@ -1,0 +1,133 @@
+{{
+    config(
+        indexes=[
+            {'columns': ['sequencing_run_id'], 'type': 'btree'},
+            {'columns': ['sequencing_run_date'], 'type': 'btree'},
+            {'columns': ['library_id'], 'type': 'btree'},
+            {'columns': ['internal_subject_id'], 'type': 'btree'},
+            {'columns': ['external_subject_id'], 'type': 'btree'},
+            {'columns': ['sample_id'], 'type': 'btree'},
+            {'columns': ['external_sample_id'], 'type': 'btree'},
+            {'columns': ['experiment_id'], 'type': 'btree'},
+            {'columns': ['project_id'], 'type': 'btree'},
+            {'columns': ['owner_id'], 'type': 'btree'},
+            {'columns': ['workflow'], 'type': 'btree'},
+            {'columns': ['phenotype'], 'type': 'btree'},
+            {'columns': ['type'], 'type': 'btree'},
+            {'columns': ['assay'], 'type': 'btree'},
+            {'columns': ['quality'], 'type': 'btree'},
+            {'columns': ['source'], 'type': 'btree'},
+            {'columns': ['load_datetime'], 'type': 'btree'},
+        ]
+    )
+}}
+
+with transformed as (
+
+    select
+
+        sqr.sequencing_run_id as sequencing_run_id,
+        cast((regexp_match(sqr.sequencing_run_id, '(?:^)(\d{6})(?:_A\d{5}_\d{4}_[A-Z0-9]{10})'))[1] as date) as sequencing_run_date,
+        lib.library_id as library_id,
+        int_sbj.internal_subject_id as internal_subject_id,
+        ext_sbj.external_subject_id as external_subject_id,
+        smp.sample_id as sample_id,
+        ext_smp.external_sample_id as external_sample_id,
+        expr.experiment_id as experiment_id,
+        prj.project_id as project_id,
+        owner.owner_id as owner_id,
+        coalesce(sat.workflow, sat2.workflow) as workflow,
+        coalesce(sat.phenotype, sat2.phenotype) as phenotype,
+        coalesce(sat.type, sat2.type) as type,
+        coalesce(sat.assay, sat2.assay) as assay,
+        coalesce(sat.quality, sat2.quality) as quality,
+        sat.source as source,
+        sat.truseq_index as truseq_index,
+        coalesce(sat.load_datetime, sat2.load_datetime) as load_datetime
+
+    from
+
+        {{ ref('hub_library') }} lib
+
+            left join {{ ref('link_library_sequencing_run') }} lnk1 on lib.library_hk = lnk1.library_hk
+            left join {{ ref('hub_sequencing_run') }} sqr on lnk1.sequencing_run_hk = sqr.sequencing_run_hk
+
+            left join {{ ref('link_library_internal_subject') }} lnk2 on lib.library_hk = lnk2.library_hk
+            left join {{ ref('hub_internal_subject') }} int_sbj on lnk2.internal_subject_hk = int_sbj.internal_subject_hk
+
+            left join {{ ref('link_library_external_subject') }} lnk3 on lib.library_hk = lnk3.library_hk
+            left join {{ ref('hub_external_subject') }} ext_sbj on lnk3.external_subject_hk = ext_sbj.external_subject_hk
+
+            left join {{ ref('link_library_sample') }} lnk4 on lib.library_hk = lnk4.library_hk
+            left join {{ ref('hub_sample') }} smp on lnk4.sample_hk = smp.sample_hk
+
+            left join {{ ref('link_library_external_sample') }} lnk5 on lib.library_hk = lnk5.library_hk
+            left join {{ ref('hub_external_sample') }} ext_smp on lnk5.external_sample_hk = ext_smp.external_sample_hk
+
+            left join {{ ref('link_library_experiment') }} lnk6 on lib.library_hk = lnk6.library_hk
+            left join {{ ref('hub_experiment') }} expr on lnk6.experiment_hk = expr.experiment_hk
+
+            left join {{ ref('link_library_project') }} lnk7 on lib.library_hk = lnk7.library_hk
+            left join {{ ref('hub_project') }} prj on lnk7.project_hk = prj.project_hk
+
+            left join {{ ref('link_library_ownership') }} lnk8 on lib.library_hk = lnk8.library_hk
+            left join {{ ref('hub_owner') }} owner on lnk8.owner_hk = owner.owner_hk
+
+            left join {{ ref('sat_library_glab') }} sat on lib.library_hk = sat.library_hk
+            left join {{ ref('sat_library_mm') }} sat2 on lib.library_hk = sat2.library_hk
+
+),
+
+filtered as (
+
+    select
+        *
+    from
+        transformed
+    where
+        project_id in ('PDAC-HMF')
+        or
+        (
+            owner_id = 'Grimmond'
+            and project_id in (
+                select
+                    distinct prj.project_id
+                from
+                    {{ ref('hub_project') }} prj
+                        join {{ ref('link_project_ownership') }} lnk on prj.project_hk = lnk.project_hk
+                        join {{ ref('hub_owner') }} owner on lnk.owner_hk = owner.owner_hk
+                where
+                    owner.owner_id = 'Grimmond'
+            )
+        )
+
+),
+
+final as (
+
+    select
+        cast(sequencing_run_id as varchar(255)) as sequencing_run_id,
+        cast(sequencing_run_date as date) as sequencing_run_date,
+        cast(library_id as varchar(255)) as library_id,
+        cast(internal_subject_id as varchar(255)) as internal_subject_id,
+        cast(external_subject_id as varchar(255)) as external_subject_id,
+        cast(sample_id as varchar(255)) as sample_id,
+        cast(external_sample_id as varchar(255)) as external_sample_id,
+        cast(experiment_id as varchar(255)) as experiment_id,
+        cast(project_id as varchar(255)) as project_id,
+        cast(owner_id as varchar(255)) as owner_id,
+        cast(workflow as varchar(255)) as workflow,
+        cast(phenotype as varchar(255)) as phenotype,
+        cast(type as varchar(255)) as type,
+        cast(assay as varchar(255)) as assay,
+        cast(quality as varchar(255)) as quality,
+        cast(source as varchar(255)) as source,
+        cast(truseq_index as varchar(255)) as truseq_index,
+        cast(load_datetime as timestamptz) as load_datetime
+    from
+        filtered
+    order by sequencing_run_date desc nulls last, library_id desc
+
+)
+
+select * from final

--- a/orcavault/models/mart/tothill/_schema.yml
+++ b/orcavault/models/mart/tothill/_schema.yml
@@ -1,0 +1,9 @@
+version: 2
+
+models:
+
+  - name: tothill_lims
+    description: Listing of Tothill Research Group LIMS metadata in flat table model
+
+  - name: tothill_fastq
+    description: Listing of Tothill Research Group primary read level FASTQ S3 locations in flat table model

--- a/orcavault/models/mart/tothill/tothill_fastq.sql
+++ b/orcavault/models/mart/tothill/tothill_fastq.sql
@@ -1,0 +1,60 @@
+{{
+    config(
+        indexes=[
+            {'columns': ['sequencing_run_id'], 'type': 'btree'},
+            {'columns': ['sequencing_run_date'], 'type': 'btree'},
+            {'columns': ['portal_run_id'], 'type': 'btree'},
+            {'columns': ['library_id'], 'type': 'btree'},
+            {'columns': ['bucket'], 'type': 'btree'},
+            {'columns': ['key'], 'type': 'btree'},
+            {'columns': ['filename'], 'type': 'btree'},
+            {'columns': ['format'], 'type': 'btree'},
+            {'columns': ['size'], 'type': 'btree'},
+            {'columns': ['storage_class'], 'type': 'btree'},
+            {'columns': ['last_modified_date'], 'type': 'btree'},
+        ]
+    )
+}}
+
+with transformed as (
+
+    select
+        lims.sequencing_run_id as sequencing_run_id,
+        fq.sequencing_run_date as sequencing_run_date,
+        fq.portal_run_id,
+        fq.bucket as bucket,
+        fq.key as "key",
+        lims.library_id as library_id,
+        fq.filename as filename,
+        fq.format as format,
+        fq.size as "size",
+        fq.storage_class as storage_class,
+        fq.e_tag as e_tag,
+        fq.last_modified_date as last_modified_date
+    from {{ ref('fastq') }} fq
+        join {{ ref('tothill_lims') }} lims on lims.library_id = fq.library_id and lims.sequencing_run_id = fq.sequencing_run_id
+
+),
+
+final as (
+
+    select
+        cast(sequencing_run_id as varchar(255)) as sequencing_run_id,
+        cast(sequencing_run_date as date) as sequencing_run_date,
+        cast(portal_run_id as varchar(255)) as portal_run_id,
+        cast(bucket as varchar(255)) as bucket,
+        cast("key" as text) as "key",
+        cast(library_id as varchar(255)) as library_id,
+        cast(filename as text) as filename,
+        cast(format as varchar(255)) as format,
+        cast("size" as bigint) as "size",
+        cast(storage_class as varchar(255)) as storage_class,
+        cast(e_tag as varchar(255)) as e_tag,
+        cast(last_modified_date as timestamptz) as last_modified_date
+    from
+        transformed
+    order by sequencing_run_date desc nulls last, library_id desc
+
+)
+
+select * from final

--- a/orcavault/models/mart/tothill/tothill_lims.sql
+++ b/orcavault/models/mart/tothill/tothill_lims.sql
@@ -1,0 +1,73 @@
+{{
+    config(
+        indexes=[
+            {'columns': ['sequencing_run_id'], 'type': 'btree'},
+            {'columns': ['sequencing_run_date'], 'type': 'btree'},
+            {'columns': ['library_id'], 'type': 'btree'},
+            {'columns': ['internal_subject_id'], 'type': 'btree'},
+            {'columns': ['external_subject_id'], 'type': 'btree'},
+            {'columns': ['sample_id'], 'type': 'btree'},
+            {'columns': ['external_sample_id'], 'type': 'btree'},
+            {'columns': ['experiment_id'], 'type': 'btree'},
+            {'columns': ['project_id'], 'type': 'btree'},
+            {'columns': ['owner_id'], 'type': 'btree'},
+            {'columns': ['workflow'], 'type': 'btree'},
+            {'columns': ['phenotype'], 'type': 'btree'},
+            {'columns': ['type'], 'type': 'btree'},
+            {'columns': ['assay'], 'type': 'btree'},
+            {'columns': ['quality'], 'type': 'btree'},
+            {'columns': ['source'], 'type': 'btree'},
+            {'columns': ['load_datetime'], 'type': 'btree'},
+        ]
+    )
+}}
+
+with transformed as (
+
+    select
+        *
+    from
+        {{ ref('lims') }}
+    where
+        owner_id = 'Tothill'
+        and project_id in (
+            select
+                distinct prj.project_id
+            from
+                {{ ref('hub_project') }} prj
+                    join {{ ref('link_project_ownership') }} lnk on prj.project_hk = lnk.project_hk
+                    join {{ ref('hub_owner') }} owner on lnk.owner_hk = owner.owner_hk
+            where
+                owner.owner_id = 'Tothill'
+        )
+
+),
+
+final as (
+
+    select
+        cast(sequencing_run_id as varchar(255)) as sequencing_run_id,
+        cast(sequencing_run_date as date) as sequencing_run_date,
+        cast(library_id as varchar(255)) as library_id,
+        cast(internal_subject_id as varchar(255)) as internal_subject_id,
+        cast(external_subject_id as varchar(255)) as external_subject_id,
+        cast(sample_id as varchar(255)) as sample_id,
+        cast(external_sample_id as varchar(255)) as external_sample_id,
+        cast(experiment_id as varchar(255)) as experiment_id,
+        cast(project_id as varchar(255)) as project_id,
+        cast(owner_id as varchar(255)) as owner_id,
+        cast(workflow as varchar(255)) as workflow,
+        cast(phenotype as varchar(255)) as phenotype,
+        cast(type as varchar(255)) as type,
+        cast(assay as varchar(255)) as assay,
+        cast(quality as varchar(255)) as quality,
+        cast(source as varchar(255)) as source,
+        cast(truseq_index as varchar(255)) as truseq_index,
+        cast(load_datetime as timestamptz) as load_datetime
+    from
+        transformed
+    order by sequencing_run_date desc nulls last, library_id desc
+
+)
+
+select * from final


### PR DESCRIPTION
Concept

* Introduce "Data Mart per Research Group" and "Centre Mart" for data oversight/overseer
* Data Marts are purpose-built single table, flat model for simplicity and performance.
  Mart tables are basically light-weight and refresh on daily data loading basis; pull out
  latest from the warehouse consolidated DCL data vault layer.
* Rows are filtered for active records only; indexed and, sorted strategically to fit for
  easing the end user query experience.
