### PR TITLE
Implemented SRM satellites for HubSequencingRun constellation

### DIFF
--- a/orcavault/models/dcl/sat_schema.yml
+++ b/orcavault/models/dcl/sat_schema.yml
@@ -673,3 +673,107 @@ models:
         data_type: varchar(255)
       - name: ext3
         data_type: varchar(255)
+
+  - name: sat_sequencing_run_comment
+    config:
+      contract: { enforced: true }
+    constraints:
+      - type: primary_key
+        columns: [ sequencing_run_hk, sequencing_run_sq, load_datetime ]
+      - type: foreign_key
+        columns: [ sequencing_run_hk ]
+        to: ref('hub_sequencing_run')
+        to_columns: [ sequencing_run_hk ]
+    columns:
+      - name: sequencing_run_hk
+        data_type: char(64)
+      - name: sequencing_run_sq
+        data_type: char(64)
+      - name: load_datetime
+        data_type: timestamptz
+      - name: record_source
+        data_type: varchar(255)
+      - name: hash_diff
+        data_type: char(64)
+      - name: orcabus_id
+        data_type: char(26)
+      - name: created_by
+        data_type: varchar(255)
+      - name: created_at
+        data_type: timestamptz
+      - name: updated_at
+        data_type: timestamptz
+      - name: is_deleted
+        data_type: boolean
+      - name: comment
+        data_type: text
+
+  - name: sat_sequencing_run_detail
+    config:
+      contract: { enforced: true }
+    constraints:
+      - type: primary_key
+        columns: [ sequencing_run_hk, load_datetime ]
+      - type: foreign_key
+        columns: [ sequencing_run_hk ]
+        to: ref('hub_sequencing_run')
+        to_columns: [ sequencing_run_hk ]
+    columns:
+      - name: sequencing_run_hk
+        data_type: char(64)
+      - name: load_datetime
+        data_type: timestamptz
+      - name: record_source
+        data_type: varchar(255)
+      - name: hash_diff
+        data_type: char(64)
+      - name: orcabus_id
+        data_type: char(26)
+      - name: status
+        data_type: varchar(255)
+      - name: start_time
+        data_type: timestamptz
+      - name: end_time
+        data_type: timestamptz
+      - name: reagent_barcode
+        data_type: varchar(255)
+      - name: flowcell_barcode
+        data_type: varchar(255)
+      - name: ica_project_id
+        data_type: varchar(255)
+      - name: v1pre3_id
+        data_type: varchar(255)
+      - name: basespace_run_id
+        data_type: varchar(255)
+      - name: experiment_name
+        data_type: varchar(255)
+
+  - name: sat_sequencing_run_samplesheet
+    config:
+      contract: { enforced: true }
+    constraints:
+      - type: primary_key
+        columns: [ sequencing_run_hk, load_datetime ]
+      - type: foreign_key
+        columns: [ sequencing_run_hk ]
+        to: ref('hub_sequencing_run')
+        to_columns: [ sequencing_run_hk ]
+    columns:
+      - name: sequencing_run_hk
+        data_type: char(64)
+      - name: load_datetime
+        data_type: timestamptz
+      - name: record_source
+        data_type: varchar(255)
+      - name: hash_diff
+        data_type: char(64)
+      - name: orcabus_id
+        data_type: char(26)
+      - name: association_status
+        data_type: varchar(255)
+      - name: association_timestamp
+        data_type: timestamptz
+      - name: samplesheet_name
+        data_type: varchar(255)
+      - name: samplesheet_content
+        data_type: jsonb

--- a/orcavault/models/dcl/sat_sequencing_run_comment.sql
+++ b/orcavault/models/dcl/sat_sequencing_run_comment.sql
@@ -1,0 +1,71 @@
+{{
+    config(
+        materialized='incremental',
+        incremental_strategy='append',
+        on_schema_change='fail'
+    )
+}}
+
+with source as (
+
+    select
+        seq.instrument_run_id as sequencing_run_id,
+        cmt.orcabus_id as orcabus_id,
+        cmt.created_by as created_by,
+        cmt.created_at as created_at,
+        cmt.updated_at as updated_at,
+        cmt.is_deleted as is_deleted,
+        cmt.comment as comment
+    from {{ source('ods', 'sequence_run_manager_sequence') }} seq
+        join {{ source('ods', 'sequence_run_manager_comment') }} cmt on cmt.association_id = seq.orcabus_id
+    {% if is_incremental() %}
+    where
+        cast(cmt.created_at as timestamptz) > ( select coalesce(max(load_datetime), '1900-01-01') as ldts from {{ this }} )
+    {% endif %}
+
+),
+
+transformed as (
+
+    select
+        encode(sha256(cast(sequencing_run_id as bytea)), 'hex') as sequencing_run_hk,
+        cast('{{ run_started_at }}' as timestamptz) as load_datetime,
+        (select 'sequence_run_manager_comment') as record_source,
+        encode(sha256(concat(
+            orcabus_id,
+            created_by,
+            created_at,
+            updated_at,
+            is_deleted
+        )::bytea), 'hex') as hash_diff,
+        orcabus_id,
+        created_by,
+        created_at,
+        updated_at,
+        is_deleted,
+        comment
+    from
+        source
+
+),
+
+final as (
+
+    select
+        cast(sequencing_run_hk as char(64)) as sequencing_run_hk,
+        cast(hash_diff as char(64)) as sequencing_run_sq,
+        cast(load_datetime as timestamptz) as load_datetime,
+        cast(record_source as varchar(255)) as record_source,
+        cast(hash_diff as char(64)) as hash_diff,
+        cast(orcabus_id as char(26)) as orcabus_id,
+        cast(created_by as varchar(255)) as created_by,
+        cast(created_at as timestamptz) as created_at,
+        cast(updated_at as timestamptz) as updated_at,
+        cast(is_deleted as boolean) as is_deleted,
+        cast(comment as text) as comment
+    from
+        transformed
+
+)
+
+select * from final

--- a/orcavault/models/dcl/sat_sequencing_run_detail.sql
+++ b/orcavault/models/dcl/sat_sequencing_run_detail.sql
@@ -1,0 +1,86 @@
+{{
+    config(
+        materialized='incremental',
+        incremental_strategy='append',
+        on_schema_change='fail'
+    )
+}}
+
+with source as (
+
+    select
+        instrument_run_id as sequencing_run_id,
+        orcabus_id,
+        status,
+        start_time,
+        end_time,
+        reagent_barcode,
+        flowcell_barcode,
+        ica_project_id,
+        v1pre3_id,
+        sequence_run_id as basespace_run_id,
+        experiment_name
+    from {{ source('ods', 'sequence_run_manager_sequence') }}
+    {% if is_incremental() %}
+    where
+        cast(start_time as timestamptz) > ( select coalesce(max(load_datetime), '1900-01-01') as ldts from {{ this }} )
+    {% endif %}
+
+),
+
+transformed as (
+
+    select
+        encode(sha256(cast(sequencing_run_id as bytea)), 'hex') as sequencing_run_hk,
+        cast('{{ run_started_at }}' as timestamptz) as load_datetime,
+        (select 'sequence_run_manager_sequence') as record_source,
+        encode(sha256(concat(
+            orcabus_id,
+            status,
+            start_time,
+            end_time,
+            reagent_barcode,
+            flowcell_barcode,
+            ica_project_id,
+            v1pre3_id,
+            basespace_run_id,
+            experiment_name
+        )::bytea), 'hex') as hash_diff,
+        orcabus_id,
+        status,
+        start_time,
+        end_time,
+        reagent_barcode,
+        flowcell_barcode,
+        ica_project_id,
+        v1pre3_id,
+        basespace_run_id,
+        experiment_name
+    from
+        source
+
+),
+
+final as (
+
+    select
+        cast(sequencing_run_hk as char(64)) as sequencing_run_hk,
+        cast(load_datetime as timestamptz) as load_datetime,
+        cast(record_source as varchar(255)) as record_source,
+        cast(hash_diff as char(64)) as hash_diff,
+        cast(orcabus_id as char(26)) as orcabus_id,
+        cast(status as varchar(255)) as status,
+        cast(start_time as timestamptz) as start_time,
+        cast(end_time as timestamptz) as end_time,
+        cast(reagent_barcode as varchar(255)) as reagent_barcode,
+        cast(flowcell_barcode as varchar(255)) as flowcell_barcode,
+        cast(ica_project_id as varchar(255)) as ica_project_id,
+        cast(v1pre3_id as varchar(255)) as v1pre3_id,
+        cast(basespace_run_id as varchar(255)) as basespace_run_id,
+        cast(experiment_name as varchar(255)) as experiment_name
+    from
+        transformed
+
+)
+
+select * from final

--- a/orcavault/models/dcl/sat_sequencing_run_samplesheet.sql
+++ b/orcavault/models/dcl/sat_sequencing_run_samplesheet.sql
@@ -1,0 +1,66 @@
+{{
+    config(
+        materialized='incremental',
+        incremental_strategy='append',
+        on_schema_change='fail'
+    )
+}}
+
+with source as (
+
+    select
+        seq.instrument_run_id as sequencing_run_id,
+        ss.orcabus_id as orcabus_id,
+        ss.association_status as association_status,
+        ss.association_timestamp as association_timestamp,
+        ss.sample_sheet_name as samplesheet_name,
+        ss.sample_sheet_content as samplesheet_content
+    from {{ source('ods', 'sequence_run_manager_sequence') }} seq
+        join {{ source('ods', 'sequence_run_manager_samplesheet') }} ss on ss.sequence_id = seq.orcabus_id
+    {% if is_incremental() %}
+    where
+        cast(ss.association_timestamp as timestamptz) > ( select coalesce(max(load_datetime), '1900-01-01') as ldts from {{ this }} )
+    {% endif %}
+
+),
+
+transformed as (
+
+    select
+        encode(sha256(cast(sequencing_run_id as bytea)), 'hex') as sequencing_run_hk,
+        cast('{{ run_started_at }}' as timestamptz) as load_datetime,
+        (select 'sequence_run_manager_samplesheet') as record_source,
+        encode(sha256(concat(
+            orcabus_id,
+            association_status,
+            association_timestamp,
+            samplesheet_name
+        )::bytea), 'hex') as hash_diff,
+        orcabus_id,
+        association_status,
+        association_timestamp,
+        samplesheet_name,
+        samplesheet_content
+    from
+        source
+
+),
+
+final as (
+
+    select
+        cast(sequencing_run_hk as char(64)) as sequencing_run_hk,
+        cast(load_datetime as timestamptz) as load_datetime,
+        cast(record_source as varchar(255)) as record_source,
+        cast(hash_diff as char(64)) as hash_diff,
+        cast(orcabus_id as char(26)) as orcabus_id,
+        cast(association_status as varchar(255)) as association_status,
+        cast(association_timestamp as timestamptz) as association_timestamp,
+        cast(samplesheet_name as varchar(255)) as samplesheet_name,
+        cast(samplesheet_content as jsonb) as samplesheet_content
+    from
+        transformed
+
+)
+
+select * from final


### PR DESCRIPTION
* Straight forward implementation for SequenceRunManager descriptive values
  as satellites tables. Append only incremental strategy using respective time
  columns from source tables. The `sat_sequencing_run_comment` model requires
  using `hash_diff` sub-sequence number bec it exhibits multi-active records pattern.
