### PR TITLE
Implemented FASTQ History data mart view

### DIFF
--- a/orcavault/macros/grant_select.sql
+++ b/orcavault/macros/grant_select.sql
@@ -2,6 +2,13 @@
 {% set sql %}
     GRANT USAGE ON SCHEMA mart TO {{ role }};
     GRANT SELECT ON ALL tables IN SCHEMA mart TO {{ role }};
+
+    {# FIXME to be finalised - experimental alias views on public schema for AppSync GraphQL introspection purpose #}
+    CREATE VIEW public.lims as SELECT * FROM mart.lims;
+    CREATE VIEW public.fastq as SELECT * FROM mart.fastq;
+    CREATE VIEW public.fastq_history as SELECT * FROM mart.fastq_history;
+    GRANT USAGE ON SCHEMA public TO {{ role }};
+    GRANT SELECT ON ALL tables IN SCHEMA public TO {{ role }};
 {% endset %}
 
 {% do run_query(sql) %}

--- a/orcavault/models/mart/centre/_schema.yml
+++ b/orcavault/models/mart/centre/_schema.yml
@@ -7,3 +7,6 @@ models:
 
   - name: fastq
     description: Listing of Centre genomic sequencing unaligned read level FASTQ S3 locations in flat table model
+
+  - name: fastq_history
+    description: Listing of Centre genomic sequencing unaligned read level FASTQ S3 historical locations. Filter by library_id in WHERE clause.

--- a/orcavault/models/mart/centre/fastq_history.sql
+++ b/orcavault/models/mart/centre/fastq_history.sql
@@ -1,0 +1,69 @@
+{{
+    config(
+        materialized='view'
+    )
+}}
+
+with transformed as (
+
+    select
+        hub.bucket as bucket,
+        hub.key as "key",
+        effsat.effective_from as effective_from,
+        effsat.effective_to as effective_to,
+        effsat.is_current as is_current,
+        effsat.is_deleted as is_deleted,
+        effsat.reason as reason,
+        effsat.storage_class as storage_class,
+        (regexp_match(hub."key", '(?:/)(\d{8}[a-zA-Z0-9]{8})(?:/)'))[1] as portal_run_id,
+        (regexp_match(hub."key", '(?:/)(\d{6}_A\d{5}_\d{4}_[A-Z0-9]{10})(?:/)'))[1] as sequencing_run_id,
+        sat.library_id as library_id,
+        sat.filename as filename,
+        sat.ext1 as ext1,
+        sat.ext2 as ext2,
+        sat.ext3 as ext3,
+        effsat.size as "size",
+        effsat.e_tag as e_tag,
+        effsat.last_modified_date as last_modified_date,
+        effsat.attributes as filemanager_annotated_attributes,
+        effsat.ingest_id as filemanager_ingest_id,
+        effsat.s3_object_id as filemanager_s3object_id
+    from {{ ref('hub_s3object') }} hub
+        join {{ ref('sat_s3object_by_library') }} sat on sat.s3object_hk = hub.s3object_hk
+        join {{ ref('sat_s3object_current') }} effsat on effsat.s3object_hk = hub.s3object_hk
+    where
+        sat.ext2 = 'fastq'
+
+),
+
+final as (
+
+    select
+        cast(bucket as varchar(255)) as bucket,
+        cast("key" as text) as "key",
+        cast(effective_from as timestamptz) as effective_from,
+        cast(effective_to as timestamptz) as effective_to,
+        cast(is_current as smallint) as is_current,
+        cast(is_deleted as smallint) as is_deleted,
+        cast(reason as varchar(255)) as reason,
+        cast(storage_class as varchar(255)) as storage_class,
+        cast(portal_run_id as char(16)) as portal_run_id,
+        cast(sequencing_run_id as varchar(255)) as sequencing_run_id,
+        cast(library_id as varchar(255)) as library_id,
+        cast(filename as text) as filename,
+        cast(ext1 as varchar(255)) as ext1,
+        cast(ext2 as varchar(255)) as ext2,
+        cast(ext3 as varchar(255)) as ext3,
+        cast("size" as bigint) as "size",
+        cast(e_tag as varchar(255)) as e_tag,
+        cast(last_modified_date as timestamptz) as last_modified_date,
+        cast(filemanager_annotated_attributes as jsonb) as filemanager_annotated_attributes,
+        cast(filemanager_ingest_id as uuid) as filemanager_ingest_id,
+        cast(filemanager_s3object_id as uuid) as filemanager_s3object_id
+    from
+        transformed
+    order by effective_from
+
+)
+
+select * from final


### PR DESCRIPTION
* Listing of Centre genomic sequencing unaligned read level FASTQ S3 historical locations.
  Filter by library_id in WHERE clause.
