### PR TITLE
Improved Centre lims data mart to exclude failed sequencing runs

### DIFF
--- a/orcavault/models/mart/centre/lims.sql
+++ b/orcavault/models/mart/centre/lims.sql
@@ -22,7 +22,7 @@
     )
 }}
 
-with effecitve_sequencing_run as (
+with effective_sequencing_run as (
 
     select distinct
         hub.sequencing_run_hk,
@@ -81,7 +81,7 @@ transformed as (
         {{ ref('hub_library') }} lib
 
             left join {{ ref('link_library_sequencing_run') }} lnk1 on lib.library_hk = lnk1.library_hk
-            left join effecitve_sequencing_run sqr on lnk1.sequencing_run_hk = sqr.sequencing_run_hk and sqr.status <> 'FAILED'
+            left join effective_sequencing_run sqr on lnk1.sequencing_run_hk = sqr.sequencing_run_hk and sqr.status <> 'FAILED'
 
             left join {{ ref('link_library_internal_subject') }} lnk2 on lib.library_hk = lnk2.library_hk
             left join {{ ref('hub_internal_subject') }} int_sbj on lnk2.internal_subject_hk = int_sbj.internal_subject_hk

--- a/orcavault/models/mart/centre/lims.sql
+++ b/orcavault/models/mart/centre/lims.sql
@@ -22,7 +22,18 @@
     )
 }}
 
-with effective_link_library_experiment as (
+with effecitve_sequencing_run as (
+
+    select distinct
+        hub.sequencing_run_hk,
+        hub.sequencing_run_id,
+        sat.status
+    from {{ ref('hub_sequencing_run') }} hub
+        join {{ ref('sat_sequencing_run_detail') }} sat on hub.sequencing_run_hk = sat.sequencing_run_hk
+
+),
+
+effective_link_library_experiment as (
 
     select
         lnk.*
@@ -70,7 +81,7 @@ transformed as (
         {{ ref('hub_library') }} lib
 
             left join {{ ref('link_library_sequencing_run') }} lnk1 on lib.library_hk = lnk1.library_hk
-            left join {{ ref('hub_sequencing_run') }} sqr on lnk1.sequencing_run_hk = sqr.sequencing_run_hk
+            left join effecitve_sequencing_run sqr on lnk1.sequencing_run_hk = sqr.sequencing_run_hk and sqr.status <> 'FAILED'
 
             left join {{ ref('link_library_internal_subject') }} lnk2 on lib.library_hk = lnk2.library_hk
             left join {{ ref('hub_internal_subject') }} int_sbj on lnk2.internal_subject_hk = int_sbj.internal_subject_hk


### PR DESCRIPTION
* For Centre lims mart, the business only want to have "effective" sequencing runs.
  Exclude any sequencing runs that deems FAILED by upstream SequenceRunManager data feed.

Error Mart Concept

* The future plan is to build "error mart" concept model where it shows business user
  on all outliers and unexpected cases from the operational data feed. This business
  intelligence will then be mapped and curated at mart and feed back to decision makers
  and, carry out necessary actions by system stakeholder.
