### PR TITLE
Implemented business vault effectivity satellites on Library to Sample, ExternalSample and Project

### DIFF
--- a/orcavault/models/dcl/effsat_library_external_sample.sql
+++ b/orcavault/models/dcl/effsat_library_external_sample.sql
@@ -1,0 +1,169 @@
+{{
+    config(
+        indexes=[
+            {'columns': ['effective_from'], 'type': 'btree'},
+            {'columns': ['effective_to'], 'type': 'btree'},
+            {'columns': ['is_current'], 'type': 'btree'},
+            {'columns': ['effective_from', 'effective_to'], 'type': 'btree'},
+            {'columns': ['library_id'], 'type': 'btree'},
+            {'columns': ['external_sample_id'], 'type': 'btree'},
+            {'columns': ['library_id', 'external_sample_id'], 'type': 'btree'},
+            {'columns': ['hash_diff'], 'type': 'btree'},
+        ],
+        materialized='incremental',
+        incremental_strategy='merge',
+        unique_key=['hash_diff'],
+        merge_update_columns = ['effective_to', 'is_current'],
+        on_schema_change='fail'
+    )
+}}
+
+with incremental as (
+
+    select
+        distinct l.library_id
+    from {{ source('ods', 'metadata_manager_historicallibrary') }} l
+        join {{ source('ods', 'metadata_manager_sample') }} s on s.orcabus_id = l.sample_orcabus_id
+    {% if is_incremental() %}
+    where
+        cast(l.history_date as timestamptz) > ( select coalesce(max(load_datetime), '1900-01-01') as ldts from {{ this }} )
+    {% endif %}
+
+    union
+
+    select
+        distinct library_id
+    from {{ ref('spreadsheet_library_tracking_metadata') }}
+    where
+        (library_id is not null or library_id <> '') and
+        (external_sample_id is not null or external_sample_id <> '')
+    {% if is_incremental() %}
+    and
+        cast(load_datetime as timestamptz) > ( select coalesce(max(load_datetime), '1900-01-01') as ldts from {{ this }} )
+    {% endif %}
+
+    union
+
+    select
+        distinct library_id
+    from {{ ref('spreadsheet_google_lims') }}
+    where
+        (library_id is not null or library_id <> '') and
+        (external_sample_id is not null or external_sample_id <> '')
+    {% if is_incremental() %}
+    and
+        cast("timestamp" as timestamptz) + time '11:00' > ( select coalesce(max(load_datetime), '1900-01-01') as ldts from {{ this }} )
+    {% endif %}
+
+),
+
+history as (
+
+    select
+        l.library_id as library_id,
+        s.external_sample_id as external_sample_id,
+        l.history_date as association_date,
+        (select 'metadata_manager_historicallibrary') as record_source
+    from {{ source('ods', 'metadata_manager_historicallibrary') }} l
+        join {{ source('ods', 'metadata_manager_sample')}} s on s.orcabus_id = l.sample_orcabus_id
+        join incremental i on i.library_id = l.library_id
+
+    union
+
+    select
+        ss.library_id,
+        ss.external_sample_id,
+        ss.load_datetime as association_date,
+        ss.record_source
+    from {{ ref('spreadsheet_library_tracking_metadata') }} ss
+        join incremental i on i.library_id = ss.library_id
+    where
+        (ss.library_id is not null or ss.library_id <> '') and
+        (ss.external_sample_id is not null or ss.external_sample_id <> '')
+
+    union
+
+    select
+        gg.library_id,
+        gg.external_sample_id,
+        cast(gg."timestamp" as timestamptz) + time '11:00' as association_date,
+        gg.record_source
+    from {{ ref('spreadsheet_google_lims') }} gg
+        join incremental i on i.library_id = gg.library_id
+    where
+        (gg.library_id is not null or gg.library_id <> '') and
+        (gg.external_sample_id is not null or gg.external_sample_id <> '')
+
+),
+
+linked as (
+
+    select
+        lnk.library_external_sample_hk as library_external_sample_hk,
+        hl.library_id as library_id,
+        hes.external_sample_id as external_sample_id
+    from {{ ref('hub_library') }} hl
+        join {{ ref('link_library_external_sample') }} lnk on lnk.library_hk = hl.library_hk
+        join {{ ref('hub_external_sample') }} hes on lnk.external_sample_hk = hes.external_sample_hk
+
+),
+
+merged as (
+
+    select
+        linked.library_external_sample_hk as library_external_sample_hk,
+        linked.library_id as library_id,
+        linked.external_sample_id as external_sample_id,
+        history.association_date as association_date,
+        history.record_source as record_source,
+        row_number() over (partition by linked.library_id order by history.association_date desc) as rank
+    from linked
+        inner join history on linked.library_id = history.library_id and linked.external_sample_id = history.external_sample_id
+
+),
+
+transformed as (
+
+    select
+        library_external_sample_hk,
+        cast('{{ run_started_at }}' as timestamptz) as load_datetime,
+        record_source,
+        encode(sha256(concat(
+            record_source,
+            library_id,
+            external_sample_id,
+            association_date
+        )::bytea), 'hex') as hash_diff,
+        library_id,
+        external_sample_id,
+        cast(association_date as timestamptz) as effective_from,
+        case
+            when (rank = 1) then
+                cast('9999-12-31' as date)
+            else
+                lag(association_date) over (partition by library_id order by rank)
+            end as effective_to,
+        case when (rank = 1) then 1 else 0 end as is_current
+    from
+        merged
+
+),
+
+final as (
+
+    select
+        cast(library_external_sample_hk as char(64)) as library_external_sample_hk,
+        cast(load_datetime as timestamptz) as load_datetime,
+        cast(record_source as varchar(255)) as record_source,
+        cast(hash_diff as char(64)) as hash_diff,
+        cast(library_id as varchar(255)) as library_id,
+        cast(external_sample_id as varchar(255)) as external_sample_id,
+        cast(effective_from as timestamptz) as effective_from,
+        cast(effective_to as timestamptz) as effective_to,
+        cast(is_current as smallint) as is_current
+    from
+        transformed
+
+)
+
+select * from final

--- a/orcavault/models/dcl/effsat_library_project.sql
+++ b/orcavault/models/dcl/effsat_library_project.sql
@@ -1,0 +1,171 @@
+{{
+    config(
+        indexes=[
+            {'columns': ['effective_from'], 'type': 'btree'},
+            {'columns': ['effective_to'], 'type': 'btree'},
+            {'columns': ['is_current'], 'type': 'btree'},
+            {'columns': ['effective_from', 'effective_to'], 'type': 'btree'},
+            {'columns': ['library_id'], 'type': 'btree'},
+            {'columns': ['project_id'], 'type': 'btree'},
+            {'columns': ['library_id', 'project_id'], 'type': 'btree'},
+            {'columns': ['hash_diff'], 'type': 'btree'},
+        ],
+        materialized='incremental',
+        incremental_strategy='merge',
+        unique_key=['hash_diff'],
+        merge_update_columns = ['effective_to', 'is_current'],
+        on_schema_change='fail'
+    )
+}}
+
+with incremental as (
+
+    select
+        distinct l.library_id
+    from {{ source('ods', 'metadata_manager_historicallibrary') }} l
+        join {{ source('ods', 'metadata_manager_libraryprojectlink') }} lnk on lnk.library_orcabus_id = l.orcabus_id
+        join {{ source('ods', 'metadata_manager_project') }} p on lnk.project_orcabus_id = p.orcabus_id
+    {% if is_incremental() %}
+    where
+        cast(l.history_date as timestamptz) > ( select coalesce(max(load_datetime), '1900-01-01') as ldts from {{ this }} )
+    {% endif %}
+
+    union
+
+    select
+        distinct library_id
+    from {{ ref('spreadsheet_library_tracking_metadata') }}
+    where
+        (library_id is not null or library_id <> '') and
+        (project_name is not null or project_name <> '')
+    {% if is_incremental() %}
+    and
+        cast(load_datetime as timestamptz) > ( select coalesce(max(load_datetime), '1900-01-01') as ldts from {{ this }} )
+    {% endif %}
+
+    union
+
+    select
+        distinct library_id
+    from {{ ref('spreadsheet_google_lims') }}
+    where
+        (library_id is not null or library_id <> '') and
+        (project_name is not null or project_name <> '')
+    {% if is_incremental() %}
+    and
+        cast("timestamp" as timestamptz) + time '11:00' > ( select coalesce(max(load_datetime), '1900-01-01') as ldts from {{ this }} )
+    {% endif %}
+
+),
+
+history as (
+
+    select
+        l.library_id as library_id,
+        p.project_id as project_id,
+        l.history_date as association_date,
+        (select 'metadata_manager_historicallibrary') as record_source
+    from {{ source('ods', 'metadata_manager_historicallibrary') }} l
+        join {{ source('ods', 'metadata_manager_libraryprojectlink') }} lnk on lnk.library_orcabus_id = l.orcabus_id
+        join {{ source('ods', 'metadata_manager_project') }} p on lnk.project_orcabus_id = p.orcabus_id
+        join incremental i on i.library_id = l.library_id
+
+    union
+
+    select
+        ss.library_id,
+        ss.project_name as project_id,
+        ss.load_datetime as association_date,
+        ss.record_source
+    from {{ ref('spreadsheet_library_tracking_metadata') }} ss
+        join incremental i on i.library_id = ss.library_id
+    where
+        (ss.library_id is not null or ss.library_id <> '') and
+        (ss.project_name is not null or ss.project_name <> '')
+
+    union
+
+    select
+        gg.library_id,
+        gg.project_name as project_id,
+        cast(gg."timestamp" as timestamptz) + time '11:00' as association_date,
+        gg.record_source
+    from {{ ref('spreadsheet_google_lims') }} gg
+        join incremental i on i.library_id = gg.library_id
+    where
+        (gg.library_id is not null or gg.library_id <> '') and
+        (gg.project_name is not null or gg.project_name <> '')
+
+),
+
+linked as (
+
+    select
+        lnk.library_project_hk as library_project_hk,
+        hl.library_id as library_id,
+        hes.project_id as project_id
+    from {{ ref('hub_library') }} hl
+        join {{ ref('link_library_project') }} lnk on lnk.library_hk = hl.library_hk
+        join {{ ref('hub_project') }} hes on lnk.project_hk = hes.project_hk
+
+),
+
+merged as (
+
+    select
+        linked.library_project_hk as library_project_hk,
+        linked.library_id as library_id,
+        linked.project_id as project_id,
+        history.association_date as association_date,
+        history.record_source as record_source,
+        row_number() over (partition by linked.library_id order by history.association_date desc) as rank
+    from linked
+        inner join history on linked.library_id = history.library_id and linked.project_id = history.project_id
+
+),
+
+transformed as (
+
+    select
+        library_project_hk,
+        cast('{{ run_started_at }}' as timestamptz) as load_datetime,
+        record_source,
+        encode(sha256(concat(
+            record_source,
+            library_id,
+            project_id,
+            association_date
+        )::bytea), 'hex') as hash_diff,
+        library_id,
+        project_id,
+        cast(association_date as timestamptz) as effective_from,
+        case
+            when (rank = 1) then
+                cast('9999-12-31' as date)
+            else
+                lag(association_date) over (partition by library_id order by rank)
+            end as effective_to,
+        case when (rank = 1) then 1 else 0 end as is_current
+    from
+        merged
+
+),
+
+final as (
+
+    select
+        cast(library_project_hk as char(64)) as library_project_hk,
+        cast(load_datetime as timestamptz) as load_datetime,
+        cast(record_source as varchar(255)) as record_source,
+        cast(hash_diff as char(64)) as hash_diff,
+        cast(library_id as varchar(255)) as library_id,
+        cast(project_id as varchar(255)) as project_id,
+        cast(effective_from as timestamptz) as effective_from,
+        cast(effective_to as timestamptz) as effective_to,
+        cast(is_current as smallint) as is_current
+    from
+        transformed
+
+)
+
+select * from final

--- a/orcavault/models/dcl/effsat_library_sample.sql
+++ b/orcavault/models/dcl/effsat_library_sample.sql
@@ -1,0 +1,169 @@
+{{
+    config(
+        indexes=[
+            {'columns': ['effective_from'], 'type': 'btree'},
+            {'columns': ['effective_to'], 'type': 'btree'},
+            {'columns': ['is_current'], 'type': 'btree'},
+            {'columns': ['effective_from', 'effective_to'], 'type': 'btree'},
+            {'columns': ['library_id'], 'type': 'btree'},
+            {'columns': ['sample_id'], 'type': 'btree'},
+            {'columns': ['library_id', 'sample_id'], 'type': 'btree'},
+            {'columns': ['hash_diff'], 'type': 'btree'},
+        ],
+        materialized='incremental',
+        incremental_strategy='merge',
+        unique_key=['hash_diff'],
+        merge_update_columns = ['effective_to', 'is_current'],
+        on_schema_change='fail'
+    )
+}}
+
+with incremental as (
+
+    select
+        distinct l.library_id
+    from {{ source('ods', 'metadata_manager_historicallibrary') }} l
+        join {{ source('ods', 'metadata_manager_sample') }} s on s.orcabus_id = l.sample_orcabus_id
+    {% if is_incremental() %}
+    where
+        cast(l.history_date as timestamptz) > ( select coalesce(max(load_datetime), '1900-01-01') as ldts from {{ this }} )
+    {% endif %}
+
+    union
+
+    select
+        distinct library_id
+    from {{ ref('spreadsheet_library_tracking_metadata') }}
+    where
+        (library_id is not null or library_id <> '') and
+        (sample_id is not null or sample_id <> '')
+    {% if is_incremental() %}
+    and
+        cast(load_datetime as timestamptz) > ( select coalesce(max(load_datetime), '1900-01-01') as ldts from {{ this }} )
+    {% endif %}
+
+    union
+
+    select
+        distinct library_id
+    from {{ ref('spreadsheet_google_lims') }}
+    where
+        (library_id is not null or library_id <> '') and
+        (sample_id is not null or sample_id <> '')
+    {% if is_incremental() %}
+    and
+        cast("timestamp" as timestamptz) + time '11:00' > ( select coalesce(max(load_datetime), '1900-01-01') as ldts from {{ this }} )
+    {% endif %}
+
+),
+
+history as (
+
+    select
+        l.library_id as library_id,
+        s.sample_id as sample_id,
+        l.history_date as association_date,
+        (select 'metadata_manager_historicallibrary') as record_source
+    from {{ source('ods', 'metadata_manager_historicallibrary') }} l
+        join {{ source('ods', 'metadata_manager_sample')}} s on s.orcabus_id = l.sample_orcabus_id
+        join incremental i on i.library_id = l.library_id
+
+    union
+
+    select
+        ss.library_id,
+        ss.sample_id,
+        ss.load_datetime as association_date,
+        ss.record_source
+    from {{ ref('spreadsheet_library_tracking_metadata') }} ss
+        join incremental i on i.library_id = ss.library_id
+    where
+        (ss.library_id is not null or ss.library_id <> '') and
+        (ss.sample_id is not null or ss.sample_id <> '')
+
+    union
+
+    select
+        gg.library_id,
+        gg.sample_id,
+        cast(gg."timestamp" as timestamptz) + time '11:00' as association_date,
+        gg.record_source
+    from {{ ref('spreadsheet_google_lims') }} gg
+        join incremental i on i.library_id = gg.library_id
+    where
+        (gg.library_id is not null or gg.library_id <> '') and
+        (gg.sample_id is not null or gg.sample_id <> '')
+
+),
+
+linked as (
+
+    select
+        lnk.library_sample_hk as library_sample_hk,
+        hl.library_id as library_id,
+        hes.sample_id as sample_id
+    from {{ ref('hub_library') }} hl
+        join {{ ref('link_library_sample') }} lnk on lnk.library_hk = hl.library_hk
+        join {{ ref('hub_sample') }} hes on lnk.sample_hk = hes.sample_hk
+
+),
+
+merged as (
+
+    select
+        linked.library_sample_hk as library_sample_hk,
+        linked.library_id as library_id,
+        linked.sample_id as sample_id,
+        history.association_date as association_date,
+        history.record_source as record_source,
+        row_number() over (partition by linked.library_id order by history.association_date desc) as rank
+    from linked
+        inner join history on linked.library_id = history.library_id and linked.sample_id = history.sample_id
+
+),
+
+transformed as (
+
+    select
+        library_sample_hk,
+        cast('{{ run_started_at }}' as timestamptz) as load_datetime,
+        record_source,
+        encode(sha256(concat(
+            record_source,
+            library_id,
+            sample_id,
+            association_date
+        )::bytea), 'hex') as hash_diff,
+        library_id,
+        sample_id,
+        cast(association_date as timestamptz) as effective_from,
+        case
+            when (rank = 1) then
+                cast('9999-12-31' as date)
+            else
+                lag(association_date) over (partition by library_id order by rank)
+            end as effective_to,
+        case when (rank = 1) then 1 else 0 end as is_current
+    from
+        merged
+
+),
+
+final as (
+
+    select
+        cast(library_sample_hk as char(64)) as library_sample_hk,
+        cast(load_datetime as timestamptz) as load_datetime,
+        cast(record_source as varchar(255)) as record_source,
+        cast(hash_diff as char(64)) as hash_diff,
+        cast(library_id as varchar(255)) as library_id,
+        cast(sample_id as varchar(255)) as sample_id,
+        cast(effective_from as timestamptz) as effective_from,
+        cast(effective_to as timestamptz) as effective_to,
+        cast(is_current as smallint) as is_current
+    from
+        transformed
+
+)
+
+select * from final

--- a/orcavault/models/dcl/effsat_schema.yml
+++ b/orcavault/models/dcl/effsat_schema.yml
@@ -61,3 +61,93 @@ models:
         data_type: timestamptz
       - name: is_current
         data_type: smallint
+
+  - name: effsat_library_external_sample
+    config:
+      contract: { enforced: true }
+    constraints:
+      - type: primary_key
+        columns: [ library_external_sample_hk, hash_diff, load_datetime ]
+      - type: foreign_key
+        columns: [ library_external_sample_hk ]
+        to: ref('link_library_external_sample')
+        to_columns: [ library_external_sample_hk ]
+    columns:
+      - name: library_external_sample_hk
+        data_type: char(64)
+      - name: load_datetime
+        data_type: timestamptz
+      - name: record_source
+        data_type: varchar(255)
+      - name: hash_diff
+        data_type: char(64)
+      - name: library_id
+        data_type: varchar(255)
+      - name: external_sample_id
+        data_type: varchar(255)
+      - name: effective_from
+        data_type: timestamptz
+      - name: effective_to
+        data_type: timestamptz
+      - name: is_current
+        data_type: smallint
+
+  - name: effsat_library_sample
+    config:
+      contract: { enforced: true }
+    constraints:
+      - type: primary_key
+        columns: [ library_sample_hk, hash_diff, load_datetime ]
+      - type: foreign_key
+        columns: [ library_sample_hk ]
+        to: ref('link_library_sample')
+        to_columns: [ library_sample_hk ]
+    columns:
+      - name: library_sample_hk
+        data_type: char(64)
+      - name: load_datetime
+        data_type: timestamptz
+      - name: record_source
+        data_type: varchar(255)
+      - name: hash_diff
+        data_type: char(64)
+      - name: library_id
+        data_type: varchar(255)
+      - name: sample_id
+        data_type: varchar(255)
+      - name: effective_from
+        data_type: timestamptz
+      - name: effective_to
+        data_type: timestamptz
+      - name: is_current
+        data_type: smallint
+
+  - name: effsat_library_project
+    config:
+      contract: { enforced: true }
+    constraints:
+      - type: primary_key
+        columns: [ library_project_hk, hash_diff, load_datetime ]
+      - type: foreign_key
+        columns: [ library_project_hk ]
+        to: ref('link_library_project')
+        to_columns: [ library_project_hk ]
+    columns:
+      - name: library_project_hk
+        data_type: char(64)
+      - name: load_datetime
+        data_type: timestamptz
+      - name: record_source
+        data_type: varchar(255)
+      - name: hash_diff
+        data_type: char(64)
+      - name: library_id
+        data_type: varchar(255)
+      - name: project_id
+        data_type: varchar(255)
+      - name: effective_from
+        data_type: timestamptz
+      - name: effective_to
+        data_type: timestamptz
+      - name: is_current
+        data_type: smallint

--- a/orcavault/models/mart/centre/lims.sql
+++ b/orcavault/models/mart/centre/lims.sql
@@ -37,6 +37,39 @@ with effective_sequencing_run as (
 
 ),
 
+effsat_library_project as (
+
+    select
+        lnk.*
+    from {{ ref('link_library_project') }} lnk
+        join {{ ref('effsat_library_project') }} effsat on effsat.library_project_hk = lnk.library_project_hk
+    where
+        effsat.is_current = 1
+
+),
+
+effsat_library_sample as (
+
+    select
+        lnk.*
+    from {{ ref('link_library_sample') }} lnk
+        join {{ ref('effsat_library_sample') }} effsat on effsat.library_sample_hk = lnk.library_sample_hk
+    where
+        effsat.is_current = 1
+
+),
+
+effsat_library_external_sample as (
+
+    select
+        lnk.*
+    from {{ ref('link_library_external_sample') }} lnk
+        join {{ ref('effsat_library_external_sample') }} effsat on effsat.library_external_sample_hk = lnk.library_external_sample_hk
+    where
+        effsat.is_current = 1
+
+),
+
 effsat_library_external_subject as (
 
     select
@@ -104,16 +137,16 @@ transformed as (
             left join effsat_library_external_subject lnk3 on lib.library_hk = lnk3.library_hk
             left join {{ ref('hub_external_subject') }} ext_sbj on lnk3.external_subject_hk = ext_sbj.external_subject_hk
 
-            left join {{ ref('link_library_sample') }} lnk4 on lib.library_hk = lnk4.library_hk
+            left join effsat_library_sample lnk4 on lib.library_hk = lnk4.library_hk
             left join {{ ref('hub_sample') }} smp on lnk4.sample_hk = smp.sample_hk
 
-            left join {{ ref('link_library_external_sample') }} lnk5 on lib.library_hk = lnk5.library_hk
+            left join effsat_library_external_sample lnk5 on lib.library_hk = lnk5.library_hk
             left join {{ ref('hub_external_sample') }} ext_smp on lnk5.external_sample_hk = ext_smp.external_sample_hk
 
             left join effective_link_library_experiment lnk6 on lib.library_hk = lnk6.library_hk
             left join {{ ref('hub_experiment') }} expr on lnk6.experiment_hk = expr.experiment_hk
 
-            left join {{ ref('link_library_project') }} lnk7 on lib.library_hk = lnk7.library_hk
+            left join effsat_library_project lnk7 on lib.library_hk = lnk7.library_hk
             left join {{ ref('hub_project') }} prj on lnk7.project_hk = prj.project_hk
 
             left join {{ ref('link_library_ownership') }} lnk8 on lib.library_hk = lnk8.library_hk


### PR DESCRIPTION
* This is following up implementation of business vault effectivity satellites design pattern.
  EffSat tables implement business logic to close multiple relationship (links) where exists. While the
  raw vault Link table still retain the original essence of linking that has been established.
  With appropriate join on EffSat, one can reconstruct Point-In-Time snapshot of denormalized relationship.
* Updated mart `lims` table to use EffSat table current true for "current snapshot view" for reporting.
  We can build mart `lims_history` table for complete holistic view with effectivity times when needed.
