### PR TITLE
Fixed workflow run state can be null

### DIFF
--- a/orcavault/models/mart/centre/workflow.sql
+++ b/orcavault/models/mart/centre/workflow.sql
@@ -30,8 +30,8 @@ merged as (
 
     select
         *
-    from dcl.hub_workflow_run hub
-        join dcl.sat_workflow_run sat on sat.workflow_run_hk = hub.workflow_run_hk
+    from {{ ref('hub_workflow_run') }} hub
+        join {{ ref('sat_workflow_run') }} sat on sat.workflow_run_hk = hub.workflow_run_hk
 
 ),
 


### PR DESCRIPTION
* The upstream WorkflowRun may have no state.
  Such as manual override by system operator.
  See https://github.com/umccr/orcabus/issues/957
  Example `202504112d1ceb00`
* Fixed dbt ref syntax in mart Workflow table
