### PR TITLE
Implemented orcahouse management instance

### DIFF
--- a/infra/ec2/.terraform.lock.hcl
+++ b/infra/ec2/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.91.0"
+  constraints = "5.91.0"
+  hashes = [
+    "h1:bZ3AM8Qd1veQoUJqOb7OVp/ElmLg/hkz3bHL2DZZ5Tk=",
+    "zh:03ee14261b25aee94c735ed6ef7cce47900ab7bdf462335432ca034d0ba74ca2",
+    "zh:32a3759049c9c2cd041d1257cf16cb90a5ce586e1d0a6fe5f8ebd0ec1ba8e071",
+    "zh:334db69bc6d8643ec4ea432f0e54e851c2394bbe889cca29ca5029db0e4699e8",
+    "zh:39957a4a900f100ea8d85845a42164a44c9efea8559a9e74ab4f6a1193e20c3e",
+    "zh:8831396c764815eb367601a522c51c2e9e8fc38bcaa5f5e83f21de771778e9ba",
+    "zh:8e71ab68c27f909892a063f845d92faa487297ad9bbc67c77a67194e509781e6",
+    "zh:944df1084a7ea37a4feea0ee6654fd15891ef4829c5453bc149ffbcc0ab9bad7",
+    "zh:964391527624f2e66a4eb387ad0a30a1b67a896e9395b6d01353f2572723ea03",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:bb956c660185161e8ce1ed1dbf187c9f549d1779673fe798211dd5b02b98c737",
+    "zh:c237199ca8cd88f4aab4c673f848c77670b90d98a484fef6bcd31a71ff63d9b9",
+    "zh:c7522f6072f8ba29f4a6d0f994eda8a381ed2f4a41dbe44c4d989c44852cfe63",
+    "zh:d412a852ced01433c44f222952b60974f7c297a8a21bef62c9a627b050084134",
+    "zh:e420266b772041fa89e5868594ed21c8c3090d76b3ec0262054f768a7807f5a7",
+    "zh:ecfcc7844e9e01123920a4b0e667a4688654e3f22f00890ec80ddd78e7312eda",
+  ]
+}

--- a/infra/ec2/README.md
+++ b/infra/ec2/README.md
@@ -1,0 +1,87 @@
+# OrcaHouse Management Instance
+
+The stack uses terraform workspace.
+
+```
+terraform workspace list
+  default
+* prod
+```
+
+Login to the corresponding AWS account and apply like so.
+
+```
+export AWS_PROFILE=umccr-prod-admin && terraform workspace select prod && terraform plan
+terraform apply
+```
+
+## Usage
+
+The following methods work for both OrcaBus and OrcaHouse. You can set up a connection via this management host to reach out either Aurora Cluster.
+
+```
+export AWS_PROFILE=umccr-prod-admin
+```
+
+```
+aws ec2 describe-instances \
+    --filters 'Name=tag:Name,Values=orcahouse-mgmt-*' \
+    --output text \
+    --query 'Reservations[*].Instances[*].InstanceId'
+```
+
+### Method 1: Using SSM
+
+```
+aws ssm start-session --target <INSTANCE_ID>
+```
+
+```
+aws ssm start-session --target <INSTANCE_ID> \
+ --document-name AWS-StartPortForwardingSessionToRemoteHost \
+ --parameters '{"portNumber":["5432"],"localPortNumber":["9432"],"host":["<REPLACEME>-db.cluster-<REPLACEME>.ap-southeast-2.rds.amazonaws.com"]}'
+```
+
+* https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ssm/start-session.html
+* https://docs.aws.amazon.com/systems-manager/latest/userguide/getting-started-create-preferences-cli.html
+* https://aws.amazon.com/blogs/mt/use-port-forwarding-in-aws-systems-manager-session-manager-to-connect-to-remote-hosts/
+* https://aws.amazon.com/blogs/database/securely-connect-to-an-amazon-rds-or-amazon-ec2-database-instance-remotely-with-your-preferred-gui/
+
+### Method 2: Using EICE
+
+_In most cases, to make this EICE connection method work in practical sense; add your SSH public key to `~/.ssh/authorized_keys` via SSM start-session^^ for the very first time. Seek help in `#orcabus` channel, if stuck._
+
+```
+aws ec2-instance-connect open-tunnel --local-port 2222 --instance-id <INSTANCE_ID>
+```
+
+* https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2-instance-connect/index.html
+* https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-connect-methods.html
+* https://aws.amazon.com/blogs/compute/secure-connectivity-from-public-to-private-introducing-ec2-instance-connect-endpoint-june-13-2023/
+* https://www.google.com/search?q=ssh+config+host+profile
+
+### DB Credential
+
+Use **Read-Only** DB credential in most cases. Switch to Read-Write credential when appropriate or performing DBA actions. Use AWS Secret Manager Console or CLI to select the db credential. As follows.
+
+```
+aws secretsmanager list-secrets --filter Key="name",Values="orcahouse"
+```
+
+```
+aws secretsmanager list-secrets --filter Key="name",Values="orcabus"
+```
+
+Note:
+- DB credentials are rotating. Hence, you may need to script [get-secret-value](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/secretsmanager/get-secret-value.html) command.
+- Some IDE like JetBrains or VSCode support [AWS Secret Manager](https://docs.aws.amazon.com/secretsmanager/latest/userguide/integrating_how-services-use-secrets_JBIDE.html) lookup via [AWS Toolkit](https://www.google.com/search?q=AWS+Toolkit) plugin extension.
+
+### Connect DB via SSH
+
+_Every well-known database IDE would support "Connection over SSH" setting. Please try the following Google keyword searching or, ask AI/GPT prompt chat to suit your dev tool setup condition. Seek help in `#orcabus` channel, if stuck._
+
+* https://www.google.com/search?q=dbeaver+ssh
+* https://www.google.com/search?q=jebbrains+datagrip+ssh
+* https://www.google.com/search?q=jetbrains+pycharm+database+ssh
+* https://www.google.com/search?q=rstudio+database+ssh
+* https://www.google.com/search?q=vscode+database

--- a/infra/ec2/main.tf
+++ b/infra/ec2/main.tf
@@ -1,0 +1,159 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  backend "s3" {
+    bucket         = "umccr-terraform-states"
+    key            = "orcahouse-ec2/terraform.tfstate"
+    region         = "ap-southeast-2"
+    dynamodb_table = "terraform-state-lock"
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.91.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "ap-southeast-2"
+  default_tags {
+    tags = {
+      "umccr-org:Product" = "OrcaHouse"
+      "umccr-org:Creator" = "Terraform"
+      "umccr-org:Service" = "OrcaHouse"
+      "umccr-org:Source"  = "https://github.com/umccr/orcahouse"
+    }
+  }
+}
+
+locals {
+  stack_name = "orcahouse"
+}
+
+# ---
+
+variable "orcahouse_rds_sg_id" {
+  default = {
+    dev  = ""
+    prod = "sg-013b6e66086adc6a6"
+    stg  = ""
+  }
+}
+
+variable "orcabus_compute_sg_id" {
+  default = {
+    dev  = "sg-03abb47eba799e044"
+    prod = "sg-02e363a39220c955f"
+    stg  = "sg-069849c9157d4fb66"
+  }
+}
+
+variable "private_subnet_id" {
+  # az ap-southeast-2a
+  default = {
+    dev  = "subnet-050e6fb0f6028178b"
+    prod = "subnet-01be4c1109eca3446"
+    stg  = "subnet-01308be8bb704e5ef"
+  }
+}
+
+# ---
+
+data "aws_vpc" "main_vpc" {
+  tags = {
+    Name        = "main-vpc"
+    Stack       = "networking"
+    Environment = terraform.workspace
+  }
+}
+
+data "aws_security_group" "main_vpc_sg_outbound" {
+  vpc_id = data.aws_vpc.main_vpc.id
+
+  # allow outbound only traffic
+  tags = {
+    Name = "outbound_only"
+  }
+}
+
+data "aws_security_group" "main_vpc_sg_ssh_from_eice" {
+  vpc_id = data.aws_vpc.main_vpc.id
+
+  # allow EC2 Instance Connect Endpoint (eice)
+  tags = {
+    Name = "ssh_from_eice"
+  }
+}
+
+# ---
+
+resource "aws_iam_role" "ssm_instance_role" {
+  name = "${local.stack_name}-ssm-instance-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ssm_instance_policy" {
+  role       = aws_iam_role.ssm_instance_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "ssm_instance_profile" {
+  name = "${local.stack_name}-ssm-instance-profile"
+  role = aws_iam_role.ssm_instance_role.name
+}
+
+resource "aws_instance" "mgmt" {
+
+  # Find AMI with preinstalled SSM agent
+  # https://docs.aws.amazon.com/systems-manager/latest/userguide/ami-preinstalled-agent.html
+
+  # via Ec2 Console Search Filter > AMI Catalog
+  # Ubuntu Server 24.04 LTS (HVM), SSD Volume Type
+  # ami-0f5d1713c9af4fe30 (64-bit (x86)) / ami-099eeb58169040255 (64-bit (Arm))
+  ami                         = "ami-099eeb58169040255"
+  instance_type               = "t4g.nano"
+  hibernation                 = true
+  associate_public_ip_address = false
+  iam_instance_profile        = aws_iam_instance_profile.ssm_instance_profile.name
+  subnet_id                   = var.private_subnet_id[terraform.workspace]
+
+  vpc_security_group_ids = [
+    data.aws_security_group.main_vpc_sg_ssh_from_eice.id,
+    data.aws_security_group.main_vpc_sg_outbound.id,
+    var.orcahouse_rds_sg_id[terraform.workspace],
+    var.orcabus_compute_sg_id[terraform.workspace],
+  ]
+
+  root_block_device {
+    volume_size = 10
+    volume_type = "gp3"
+  }
+
+  metadata_options {
+    http_tokens = "required"
+  }
+
+  tags = {
+    Name = "${local.stack_name}-mgmt-instance"
+  }
+}
+
+# ---
+
+output "instance_id" {
+  value = aws_instance.mgmt.id
+}


### PR DESCRIPTION
* Private instance that can only connect via SSM or EICE method via a specified IAM role.
* It then allows connection to air-gapped database subnet clusters. Both for OrcaBus and OrcaHouse management.
* Added quick pointers for DevOps how to.
