### PR TITLE
Fixed dbt hook run operation grant select ro user

### DIFF
--- a/infra/ecs/orcavault-dbt/main.tf
+++ b/infra/ecs/orcavault-dbt/main.tf
@@ -66,5 +66,9 @@ data "aws_rds_cluster" "orcahouse_db" {
 }
 
 data "aws_ssm_parameter" "ro_username" {
-  name = "/${local.stack_name}/ro_username"
+  # For daily scheduled dbt run; we have to run post-ELT hook grant select
+  # to Athena db ro user for mart schema. We pass this ro username via ECS
+  # task definition env var at terraform deploy time.
+  # See orcavault/macros/grant_select.sql
+  name = "/${local.stack_name}/${local.database_name}/athena_username"
 }

--- a/orcavault/README.md
+++ b/orcavault/README.md
@@ -42,7 +42,7 @@ orcavault=> select count(1) from hub_library;
 orcavault=> \q
 ```
 
-### Make Load
+## Make Load
 
 To this point, it is good enough to work with structural changes and transformation from a previous section; i.e., data model development purpose. If you would like to try the ELT process with snapshot test data, you can sync from dev bucket. Steps are as follows.
 
@@ -72,3 +72,15 @@ dbt run
 ```
 
 Then on, it is just rinse and spin with the local dbt dev process. You may rather want to use a better database [IDE](../dev/README.md) alternate at this point; instead of `psql` CLI.
+
+## Hooks
+
+See dbt documentation for post-ELT hook to perform dbt run operation [macros](macros).
+- https://docs.getdbt.com/docs/build/hooks-operations
+- https://docs.getdbt.com/reference/commands/run-operation
+
+e.g.
+```
+export RO_USERNAME=dev
+dbt run-operation grant_select --args "{role: $RO_USERNAME}" --target dev
+```

--- a/orcavault/macros/grant_select.sql
+++ b/orcavault/macros/grant_select.sql
@@ -1,5 +1,6 @@
 {% macro grant_select(role) %}
 {% set sql %}
+    {# role is passed by dbt run exec via ECS task env var at infra deploy time. See infra/ecs/orcavault-dbt/main.tf #}
     GRANT USAGE ON SCHEMA mart TO {{ role }};
     GRANT SELECT ON ALL tables IN SCHEMA mart TO {{ role }};
 


### PR DESCRIPTION
* For daily scheduled dbt run; we have to run post-ELT hook grant select
  to Athena db ro user for mart schema. We pass this ro username via ECS
  task definition env var at terraform deploy time.
  See orcavault/macros/grant_select.sql
