### PR TITLE
Add Metadata event ingestion

### DIFF
--- a/dev/src/psa.sql
+++ b/dev/src/psa.sql
@@ -145,7 +145,7 @@ CREATE TABLE IF NOT EXISTS orcavault.psa.event__metadata_state_change_library
     type                    varchar,
     assay                   varchar,
     coverage                varchar,
-    overrideCycles          varchar,
+    override_cycles          varchar,
     sample_orcabus_id       varchar,
     subject_orcabus_id      varchar,
     load_datetime           timestamptz,

--- a/dev/src/psa.sql
+++ b/dev/src/psa.sql
@@ -131,3 +131,23 @@ CREATE TABLE IF NOT EXISTS orcavault.psa.event__workflow_run_state_change
     load_datetime       timestamptz,
     record_source       varchar(255)
 );
+
+CREATE TABLE IF NOT EXISTS orcavault.psa.event__metadata_state_change_library
+(
+    event_id                varchar,
+    event_time              varchar,
+    orcabus_id              varchar,
+    action                  varchar,
+    library_id              varchar,
+    phenotype               varchar,
+    workflow                varchar,
+    quality                 varchar,
+    type                    varchar,
+    assay                   varchar,
+    coverage                varchar,
+    overrideCycles          varchar,
+    sample_orcabus_id       varchar,
+    subject_orcabus_id      varchar,
+    load_datetime           timestamptz,
+    record_source           varchar(255)
+);

--- a/infra/service-event-ingestion/lambda/mm_lib_event_handler/mm_lib_event_handler.py
+++ b/infra/service-event-ingestion/lambda/mm_lib_event_handler/mm_lib_event_handler.py
@@ -117,7 +117,7 @@ def parse_event(event):
     lib_type = event_data.get("type")
     assay = event_data.get("assay")
     coverage = event_data.get("coverage")
-    overrideCycles = event_data.get("overrideCycles")
+    override_cycles = event_data.get("overrideCycles")
     sample_id = event_data.get("sample")
     subject_id = event_data.get("subject")
 
@@ -133,7 +133,7 @@ def parse_event(event):
         "type": lib_type,
         "assay": assay,
         "coverage": coverage,
-        "overrideCycles": overrideCycles,
+        "override_cycles": override_cycles,
         "sample_orcabus_id": sample_id,
         "subject_orcabus_id": subject_id,
         "load_datetime": datetime.datetime.now().isoformat(),

--- a/infra/service-event-ingestion/lambda/mm_lib_event_handler/mm_lib_event_handler.py
+++ b/infra/service-event-ingestion/lambda/mm_lib_event_handler/mm_lib_event_handler.py
@@ -1,0 +1,158 @@
+import os
+import json
+import datetime
+import boto3
+import psycopg2
+from psycopg2.extras import RealDictCursor
+from os.path import join
+import utils
+
+
+# Get the secret name from environment variables
+DB_SECRET_NAME = os.environ["DB_SECRET_NAME"]
+
+DB_SCHEMA = "psa"
+TABLE_NAME = "event__metadata_state_change_library"
+TABLE = f"{DB_SCHEMA}.{TABLE_NAME}"
+DETAIL_TYPE = "MetadataStateChange"
+EVENT_SOURCE = "orcabus.metadatamanager"
+SUB_TYPE = "library"
+RECORD_SOURCE = f"{EVENT_SOURCE}:{DETAIL_TYPE}:{SUB_TYPE}"
+
+# Prevent inserts of the same event record multiple times
+# TODO: consider hashing the event values and only insert records that differ
+SQL_INSERT = f"INSERT INTO {TABLE} (%s) SELECT %s WHERE NOT EXISTS (SELECT 1 FROM {TABLE} WHERE event_id = %s);"
+
+# DB connection
+session = boto3.session.Session()
+secretsmanager_client = boto3.client("secretsmanager")
+DB_CREDENTIALS = utils.get_secret(DB_SECRET_NAME, secretsmanager_client)
+DB_CONNECTION = utils.get_db_connection(DB_CREDENTIALS)
+
+
+def handler(event, context):
+    print("Lambda function invoked!")
+    print(f"Event: {event}")
+    try:
+        data = parse_event(event)
+        utils.push_to_db(DB_CONNECTION, SQL_INSERT, data)
+
+        print("Returning results.")
+        return {
+            "statusCode": 200,
+        }
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
+        raise e
+
+
+def parse_event(event):
+    # Parse the event and extract the Metadata State Change details for the Library record
+    """
+    Example MetadataStateChange event:
+    {
+        "version": "0",
+        "id": "f7dd6b99-d7cc-ca61-9577-7f7a54f60967",
+        "detail-type": "MetadataStateChange",
+        "source": "orcabus.metadatamanager",
+        "account": "472057503814",
+        "time": "2025-05-05T05:11:44Z",
+        "region": "ap-southeast-2",
+        "resources": [],
+        "detail": {
+            "action": "UPDATE",
+            "model": "LIBRARY",
+            "refId": "lib.01JBMTFP4TQZ6MMTHE9ASJNZK7",
+            "data": {
+                "orcabusId": "lib.01JBMTFP4TQZ6MMTHE9ASJNZK7",
+                "libraryId": "L1900827",
+                "phenotype": "negative-control",
+                "workflow": "control",
+                "quality": "good",
+                "type": "exome",
+                "assay": "AgSsCRE",
+                "coverage": 0.1,
+                "overrideCycles": "Y100N51;I8N2;U10;Y100N51",
+                "sample": "smp.01JBMTFP4ENWHC8NMGEMWZ4WHE",
+                "subject": "sbj.01JBMTFKRP3XNJ7BBW28R5NXTG"
+            }
+        }
+    }
+    """
+    print("Parsing event...")
+    detail_type = event.get("detail-type")
+    event_source = event.get("source")
+
+    # make sure we have an expected event type
+    if detail_type != DETAIL_TYPE:
+        raise ValueError(
+            f"Invalid event type. Expected '{DETAIL_TYPE}' but got '{detail_type}'"
+        )
+    if event_source != EVENT_SOURCE:
+        raise ValueError(
+            f"Invalid event source. Expected '{EVENT_SOURCE}' but got '{event_source}'"
+        )
+
+    event_id = event.get("id")
+    event_time = event.get("time")
+    detail = event.get("detail")
+
+    event_model = detail.get('model', "")
+    if not event_model.lower() = SUB_TYPE.lower():
+        raise ValueError(
+            f"Invalid event model type. Expected '{SUB_TYPE}' but got '{event_model}'"
+        )
+
+    orcabus_id = detail.get("refId")  # TODO: check against 'data.orcabusId' ?
+    event_action = detail.get("action")
+    event_data = detail.get("data")
+    if not event_data:
+        raise ValueError("Expected event payload data, but got nothing.")
+
+    library_id = event_data.get("libraryId")
+    phenotype = event_data.get("phenotype")
+    workflow = event_data.get("workflow")
+    quality = event_data.get("quality")
+    lib_type = event_data.get("type")
+    assay = event_data.get("assay")
+    coverage = event_data.get("coverage")
+    overrideCycles = event_data.get("overrideCycles")
+    sample_id = event_data.get("sample")
+    subject_id = event_data.get("subject")
+
+    mm_data = {
+        "event_id": event_id,
+        "event_time": event_time,
+        "orcabus_id": orcabus_id,
+        "action": event_action,
+        "library_id": library_id,
+        "phenotype": phenotype,
+        "workflow": workflow,
+        "quality": quality,
+        "type": lib_type,
+        "assay": assay,
+        "coverage": coverage,
+        "overrideCycles": overrideCycles,
+        "sample_orcabus_id": sample_id,
+        "subject_orcabus_id": subject_id,
+        "load_datetime": datetime.datetime.now().isoformat(),
+        "record_source": RECORD_SOURCE,
+    }
+    print(f"Extracted data: {mm_data}")
+
+    return mm_data
+
+
+def test_case():
+    # Execute example query
+    print("Executing query...")
+    with DB_CONNECTION:
+        with DB_CONNECTION.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(f"SELECT * FROM {TABLE_NAME} LIMIT 5")
+            results = cur.fetchall()
+
+    # Convert results to JSON-serializable format
+    print("Query executed successfully!")
+    results_list = [dict(row) for row in results]
+    print(f"Results: {results_list}")

--- a/infra/service-event-ingestion/mm.tf
+++ b/infra/service-event-ingestion/mm.tf
@@ -1,0 +1,35 @@
+################################################################################
+# Lambda for Metadata Manager event handling
+
+locals {
+  mm = {
+    lib_function_name  = "mm_lib_event_handler"
+  }
+}
+
+# Metadata State Change (library)
+module "mm_lib" {
+  source = "../common/ingest_pipe"
+
+  service_id     = "MMLIB"
+  iam_path       = "/orcavault/serviceingestion/mm_lib/"
+  db_secret_name = var.db_secret_name
+
+  event_pattern = {
+    detail-type = [
+      "MetadataStateChange"
+    ],
+    source = [
+      "orcabus.metadatamanager"
+    ]
+  }
+
+  lambda_function_name     = local.mm.lib_function_name
+  lambda_function_handler  = "${local.mm.lib_function_name}.handler"
+  lambda_source_paths      = [
+    "lambda/${local.mm.lib_function_name}",
+    "lambda/utils/utils.py"
+    ]
+  lambda_artefact_out_path = ".temp/lambda/${local.mm.lib_function_name}.zip"
+  lambda_layers            = [aws_lambda_layer_version.psycopg2_layer.arn]
+}

--- a/infra/service-event-ingestion/monitor.tf
+++ b/infra/service-event-ingestion/monitor.tf
@@ -35,6 +35,9 @@ module "lambda_error_alarms" {
     },
     "srm_llc_lambda" = {
       FunctionName = local.srm.llc_function_name
+    },
+    "mm_lib_lambda" = {
+      FunctionName = local.mm.lib_function_name
     }
   }
 

--- a/orcavault/models/psa/sources.yml
+++ b/orcavault/models/psa/sources.yml
@@ -114,3 +114,42 @@ sources:
             data_type: timestamptz
           - name: record_source
             data_type: varchar(255)
+
+  - name: psa
+    database: orcavault
+    schema: psa
+    tables:
+      - name: event__metadata_state_change_library
+        columns:
+          - name: event_id
+            data_type: varchar
+          - name: event_time
+            data_type: varchar
+          - name: orcabus_id
+            data_type: varchar
+          - name: action
+            data_type: varchar
+          - name: library_id
+            data_type: varchar
+          - name: phenotype
+            data_type: varchar
+          - name: workflow
+            data_type: varchar
+          - name: quality
+            data_type: varchar
+          - name: type
+            data_type: varchar
+          - name: assay
+            data_type: varchar
+          - name: coverage
+            data_type: varchar
+          - name: overrideCycles
+            data_type: varchar
+          - name: sample_orcabus_id
+            data_type: varchar
+          - name: subject_orcabus_id
+            data_type: varchar
+          - name: load_datetime
+            data_type: varchar
+          - name: record_source
+            data_type: varchar

--- a/orcavault/models/psa/sources.yml
+++ b/orcavault/models/psa/sources.yml
@@ -143,7 +143,7 @@ sources:
             data_type: varchar
           - name: coverage
             data_type: varchar
-          - name: overrideCycles
+          - name: override_cycles
             data_type: varchar
           - name: sample_orcabus_id
             data_type: varchar


### PR DESCRIPTION
Note: this event structure is slightly different to other OrcaBus events. 
It uses a `model` category in order to sub divide events based on the metadata model that was changed.

Perhaps we should review that and create different event types for different models. For now I added a `SUB_TYPE` classifier... 

Also note: the event data differs slightly from the data currently in the warehouse, but this could be adjusted if needed/desired.