### PR TITLE
Improved DCL satellite WorkflowRunComment

### DIFF
--- a/orcavault/models/dcl/sat_schema.yml
+++ b/orcavault/models/dcl/sat_schema.yml
@@ -581,13 +581,15 @@ models:
       contract: { enforced: true }
     constraints:
       - type: primary_key
-        columns: [ workflow_run_hk, load_datetime ]
+        columns: [ workflow_run_hk, workflow_run_sq, load_datetime ]
       - type: foreign_key
         columns: [ workflow_run_hk ]
         to: ref('hub_workflow_run')
         to_columns: [ workflow_run_hk ]
     columns:
       - name: workflow_run_hk
+        data_type: char(64)
+      - name: workflow_run_sq
         data_type: char(64)
       - name: load_datetime
         data_type: timestamptz

--- a/orcavault/models/dcl/sat_workflow_run_comment.sql
+++ b/orcavault/models/dcl/sat_workflow_run_comment.sql
@@ -54,6 +54,7 @@ final as (
 
     select
         cast(workflow_run_hk as char(64)) as workflow_run_hk,
+        cast(hash_diff as char(64)) as workflow_run_sq,
         cast(load_datetime as timestamptz) as load_datetime,
         cast(record_source as varchar(255)) as record_source,
         cast(hash_diff as char(64)) as hash_diff,


### PR DESCRIPTION
* The upstream WorkflowRunComment may add multiple comments within
  a day. Added the sub-sequencing column to track this change history
  based on the hash_diff changes to the satellite model composite PK.
