### PR TITLE
Improved DCL BV satellite WorkflowRun ETL strategy

### DIFF
--- a/orcavault/models/dcl/sat_workflow_run.sql
+++ b/orcavault/models/dcl/sat_workflow_run.sql
@@ -1,7 +1,8 @@
 {{
     config(
         materialized='incremental',
-        incremental_strategy='append',
+        incremental_strategy='merge',
+        unique_key='workflow_run_hk',
         on_schema_change='fail'
     )
 }}


### PR DESCRIPTION
* The upstream model `WorkflowRunDetail` satellite tracks all historical changes
  about workflow run records over time. Hence, in this Business Vault (BV) satellite
  `sat_workflow_run.sql` model, the business rule is to only show the "current"
  effective status of the workflow run at that point-in-time.
* Since we already have history tracking, we can simply change ETL incremental
  strategy from append to merge update on the unique business key `workflow_run_hk`.
* This will make `sat_workflow_run.sql` model to have only one `portal_run_id`
  at any point in time with any run status it may hold.
