### PR TITLE
Stripped LibraryID suffixes from Read inventory tables

### DIFF
--- a/orcavault/models/dcl/sat_s3object_by_library.sql
+++ b/orcavault/models/dcl/sat_s3object_by_library.sql
@@ -19,7 +19,7 @@ with source as (
 
     select
         s3object_hk,
-        (regexp_matches("key", '(?:L\d{7}|L(?:PRJ|CCR|MDX|TGX)\d{6}|Undetermined)(?:(?:_topup\d?)|(?:_rerun\d?))?', 'g'))[1] as library_id,
+        (regexp_matches("key", '(?:L\d{7}|L(?:PRJ|CCR|MDX|TGX)\d{6}|Undetermined)', 'g'))[1] as library_id,
         regexp_replace("key", '^.+[/\\]', '') as filename,
         split_part(regexp_replace("key", '^.+[/\\]', ''), '.', -1) as ext1,
         split_part(regexp_replace("key", '^.+[/\\]', ''), '.', -2) as ext2,

--- a/orcavault/models/mart/centre/fastq.sql
+++ b/orcavault/models/mart/centre/fastq.sql
@@ -28,7 +28,7 @@ with transformed as (
         (regexp_match(hub.key, '(?<=byob-icav2\/).+?(?=\/)'))[1] as cohort_id,
         hub.bucket as bucket,
         hub.key as "key",
-        (regexp_match(sat.filename, '(?:L\d{7}|L(?:PRJ|CCR|MDX|TGX)\d{6}|Undetermined)(?:(?:_topup\d?)|(?:_rerun\d?))?'))[1] as library_id,
+        (regexp_match(sat.filename, '(?:L\d{7}|L(?:PRJ|CCR|MDX|TGX)\d{6}|Undetermined)'))[1] as library_id,
         sat.filename as filename,
         sat.ext1 as format,
         cur.size as "size",


### PR DESCRIPTION
* When ETL data mining on the LibraryID, improve the business rule (regex pattern) to
  strip suffixes such as topup, rerun.
* This rule applies to DCL layer Business Vault satellite `sat_s3object_by_library.sql`
  index table which supports the mart `fastq_history` view and `bam` table, as well as
  the business mart `fastq.sql` model.
