### PR TITLE
Implemented Same-as Link table for LibraryHub

### DIFF
--- a/orcavault/models/dcl/sal_library.sql
+++ b/orcavault/models/dcl/sal_library.sql
@@ -1,0 +1,70 @@
+{{
+    config(
+        indexes=[
+            {'columns': ['base_library_id'], 'type': 'btree'},
+            {'columns': ['alias_library_id'], 'type': 'btree'},
+        ],
+        materialized='incremental',
+        incremental_strategy='merge',
+        unique_key='sal_library_hk',
+        on_schema_change='fail'
+    )
+}}
+
+with source as (
+
+    select
+        *
+    from
+        {{ ref('hub_library') }}
+    {% if is_incremental() %}
+    where
+        cast(load_datetime as timestamptz) > ( select coalesce(max(load_datetime), '1900-01-01') as ldts from {{ this }} )
+    {% endif %}
+
+),
+
+filtered as (
+
+    select
+        library_hk as alias_library_hk,
+        library_id as alias_library_id,
+        (regexp_match(library_id, '(?:L\d{7}|L(?:PRJ|CCR|MDX|TGX)\d{6})'))[1] as base_library_id,
+        record_source
+    from
+        source
+    where
+        library_id like '%topup%' or library_id like '%rerun%'
+
+),
+
+transformed as (
+
+    select
+        cast('{{ run_started_at }}' as timestamptz) as load_datetime,
+        record_source,
+        encode(sha256(cast(base_library_id as bytea)), 'hex') as base_library_hk,
+        alias_library_hk,
+        base_library_id,
+        alias_library_id
+    from
+        filtered
+
+),
+
+final as (
+
+    select
+        cast(encode(sha256(concat(base_library_hk, alias_library_hk)::bytea), 'hex') as char(64)) as sal_library_hk,
+        cast(base_library_hk as char(64)) as base_library_hk,
+        cast(alias_library_hk as char(64)) as alias_library_hk,
+        cast(load_datetime as timestamptz) as load_datetime,
+        cast(record_source as varchar(255)) as record_source,
+        cast(base_library_id as varchar(255)) as base_library_id,
+        cast(alias_library_id as varchar(255)) as alias_library_id
+    from
+        transformed
+
+)
+
+select * from final

--- a/orcavault/models/dcl/sal_schema.yml
+++ b/orcavault/models/dcl/sal_schema.yml
@@ -1,0 +1,33 @@
+version: 2
+
+models:
+
+  - name: sal_library
+    config:
+      contract: { enforced: true }
+    constraints:
+      - type: primary_key
+        columns: [ sal_library_hk ]
+      - type: foreign_key
+        columns: [ base_library_hk ]
+        to: ref('hub_library')
+        to_columns: [ library_hk ]
+      - type: foreign_key
+        columns: [ alias_library_hk ]
+        to: ref('hub_library')
+        to_columns: [ library_hk ]
+    columns:
+      - name: sal_library_hk
+        data_type: char(64)
+      - name: base_library_hk
+        data_type: char(64)
+      - name: alias_library_hk
+        data_type: char(64)
+      - name: load_datetime
+        data_type: timestamptz
+      - name: record_source
+        data_type: varchar(255)
+      - name: base_library_id
+        data_type: varchar(255)
+      - name: alias_library_id
+        data_type: varchar(255)


### PR DESCRIPTION
* Same-as Link (SAL) is a design pattern for creating an association between
  the two differing business keys but otherwise the same meaning by business
  context. Each instance in the Hub tracks one unique instance of the business
  key. When business provides the connection context via Master Data Management
  process (business logic rule or lookup table), SAL table can then establish
  the link between the two instances of the hub key.
* The SAL table can apply to ID alias requirement use cases. As follows.
     (forward) L0000001 -> L0000001_topup, L0000001_rerun, L0000001_topup2, [...]
     (reverse) SBJ00075 -> [...], SBJ00025, SBJ00001
