### PR TITLE
Updated DCL satellite model sat_sequencing_run_samplesheet

### DIFF
--- a/orcavault/models/dcl/sat_schema.yml
+++ b/orcavault/models/dcl/sat_schema.yml
@@ -787,13 +787,15 @@ models:
       contract: { enforced: true }
     constraints:
       - type: primary_key
-        columns: [ sequencing_run_hk, load_datetime ]
+        columns: [ sequencing_run_hk, sequencing_run_sq, load_datetime ]
       - type: foreign_key
         columns: [ sequencing_run_hk ]
         to: ref('hub_sequencing_run')
         to_columns: [ sequencing_run_hk ]
     columns:
       - name: sequencing_run_hk
+        data_type: char(64)
+      - name: sequencing_run_sq
         data_type: char(64)
       - name: load_datetime
         data_type: timestamptz

--- a/orcavault/models/dcl/sat_sequencing_run_samplesheet.sql
+++ b/orcavault/models/dcl/sat_sequencing_run_samplesheet.sql
@@ -50,6 +50,7 @@ final as (
 
     select
         cast(sequencing_run_hk as char(64)) as sequencing_run_hk,
+        cast(hash_diff as char(64)) as sequencing_run_sq,
         cast(load_datetime as timestamptz) as load_datetime,
         cast(record_source as varchar(255)) as record_source,
         cast(hash_diff as char(64)) as hash_diff,


### PR DESCRIPTION
* The upstream SequenceRunManager may link multiple SampleSheet
  within a day ELT load time. In order to support this cases, add
  subsequence number technique to Composite Primary Key.
* The subsequence number column `sequencing_run_sq` value is reusing
  of satellite descriptive attributes `hash_diff` for now.
