### PR TITLE
Fixed fastq mart library_id regexp

### DIFF
--- a/orcavault/models/mart/centre/fastq.sql
+++ b/orcavault/models/mart/centre/fastq.sql
@@ -28,7 +28,7 @@ with transformed as (
         (regexp_match(hub.key, '(?<=byob-icav2\/).+?(?=\/)'))[1] as cohort_id,
         hub.bucket as bucket,
         hub.key as "key",
-        (regexp_match(sat.filename, '(?:L\d{7}|L(?:PRJ|CCR|MDX|TGX)\d{6}|Undetermined)'))[1] as library_id,
+        (regexp_match(hub.key, '(?:L\d{7}|L(?:PRJ|CCR|MDX|TGX)\d{6}|Undetermined)'))[1] as library_id,
         sat.filename as filename,
         sat.ext1 as format,
         cur.size as "size",


### PR DESCRIPTION
* The legacy fastq file do not use library_id in the filename.
  Hence, extract (data mining) it from the hub key prefix. This
  harmonises with upstream DCL models. It should have been this
  way. Perhaps, the oversight of the initial impls.
