### PR TITLE
Implemented data mart table catalog

### DIFF
--- a/infra/ecs/orcavault-dbt/docker/run_dbt.sh
+++ b/infra/ecs/orcavault-dbt/docker/run_dbt.sh
@@ -22,6 +22,7 @@ fi
 
 dbt --version
 dbt --log-format text --no-send-anonymous-usage-stats --no-use-colors --no-quiet debug --target prod
+dbt --log-format text --no-send-anonymous-usage-stats --no-use-colors --no-quiet seed --target prod
 dbt --log-format text --no-send-anonymous-usage-stats --no-use-colors --no-quiet run --target prod
 
 dbt run-operation grant_select --args "{role: $RO_USERNAME}" --target prod

--- a/orcavault/README.md
+++ b/orcavault/README.md
@@ -30,6 +30,7 @@ dbt debug
 dbt clean
 dbt deps
 dbt build
+dbt seed
 dbt run
 ```
 
@@ -59,6 +60,7 @@ Next. Run `dbt` transformation.
 ```
 dbt test
 dbt build
+dbt seed
 dbt run
 ```
 
@@ -68,6 +70,7 @@ If you would like to reload from the start, then do like so.
 
 ```
 make reload
+dbt seed
 dbt run
 ```
 

--- a/orcavault/dbt_project.yml
+++ b/orcavault/dbt_project.yml
@@ -27,3 +27,7 @@ models:
     mart:
       +schema: mart
       +materialized: table
+
+seeds:
+  orcavault:
+    +schema: dcl

--- a/orcavault/models/mart/centre/_schema.yml
+++ b/orcavault/models/mart/centre/_schema.yml
@@ -2,20 +2,23 @@ version: 2
 
 models:
 
+  - name: catalog
+    description: Data mart table catalog
+
   - name: lims
-    description: Listing of Centre genomic sequencing LIMS metadata in flat table model.
+    description: Listing of the Centre genomic sequencing LIMS metadata in flat table model
 
   - name: fastq
-    description: Listing of Centre genomic sequencing unaligned read level file FASTQ S3 locations in flat table model.
+    description: Listing of the Centre genomic sequencing unaligned read level file FASTQ S3 locations in flat table model
 
   - name: fastq_history
-    description: Listing of Centre genomic sequencing unaligned read level file FASTQ S3 historical locations.
+    description: Listing of the Centre genomic sequencing unaligned read level file FASTQ S3 historical locations.
 
   - name: bam
-    description: Listing of Centre genomic sequencing aligned read level file BAM and BAI S3 locations in flat table model.
+    description: Listing of the Centre genomic sequencing aligned read level file BAM and BAI S3 locations in flat table model
 
   - name: workflow
-    description: Listing of Centre genomic sequencing analysis workflow run details in flat table model.
+    description: Listing of the Centre genomic sequencing analysis workflow run details in flat table model
 
   - name: accreditation_lims
-    description: Listing of Centre genomic sequencing Accreditation LIMS metadata in flat table model.
+    description: Listing of the Centre genomic sequencing Accreditation LIMS metadata in flat table model

--- a/orcavault/models/mart/centre/catalog.sql
+++ b/orcavault/models/mart/centre/catalog.sql
@@ -1,0 +1,24 @@
+{{
+    config(
+        materialized='view'
+    )
+}}
+
+with source as (
+
+    select * from {{ ref('dictionary__data_mart_catalog') }}
+
+),
+
+final as (
+
+    select
+        cast(table_name as varchar) as table_name,
+        cast(table_description as varchar) as table_description,
+        cast(table_remark as varchar) as table_remark
+    from
+        source
+
+)
+
+select * from final

--- a/orcavault/seeds/dictionary/_schema.yml
+++ b/orcavault/seeds/dictionary/_schema.yml
@@ -1,0 +1,10 @@
+version: 2
+
+seeds:
+
+  - name: dictionary__data_mart_catalog
+    config:
+      column_types:
+        table_name: varchar
+        table_description: varchar
+        table_remark: varchar

--- a/orcavault/seeds/dictionary/dictionary__data_mart_catalog.csv
+++ b/orcavault/seeds/dictionary/dictionary__data_mart_catalog.csv
@@ -1,0 +1,16 @@
+table_name,table_description,table_remark
+lims,Listing of the Centre genomic sequencing LIMS metadata in flat table model,STABLE
+fastq,Listing of the Centre genomic sequencing unaligned read level file FASTQ S3 locations in flat table model,STABLE
+fastq_history,Listing of the Centre genomic sequencing unaligned read level file FASTQ S3 historical locations,STABLE
+bam,Listing of the Centre genomic sequencing aligned read level file BAM and BAI S3 locations in flat table model,STABLE
+workflow,Listing of the Centre genomic sequencing analysis workflow run details in flat table model,STABLE
+accreditation_lims,Listing of the Centre genomic sequencing Accreditation LIMS metadata in flat table model,STABLE
+external_lims,Listing of the Externally sequenced LIMS metadata in flat table model,STABLE
+em_library_services,Listing of the Centre sequenced libray availability in OrcaBus services,STABLE
+em_library_aliases,Listing of the Centre sequenced libray aliases with run comments by lab team,STABLE
+curation_lims,Listing of the Centre Curation Team LIMS metadata in flat table model,DEMO
+grimmond_lims,Listing of Grimmond Research Group LIMS metadata in flat table model,DEMO
+dawson_lims,Listing of Dawson Research Group LIMS metadata in flat table model,DEMO
+dawson_fastq,Listing of Dawson Research Group primary read level FASTQ S3 locations in flat table model,DEMO
+tothill_lims,Listing of Tothill Research Group LIMS metadata in flat table model,DEMO
+tothill_fastq,Listing of Tothill Research Group primary read level FASTQ S3 locations in flat table model,DEMO


### PR DESCRIPTION
* Introduced `select * from mart.catalog` which describes
  the table name, description and remark for the usage and
  helps the user self-exploratory as well as self-explanatory
  about data tables present in data mart data dictionary.
* Also introduced the `dbt seed` capability to load the static
  data points from the CSV file under Seeds directory.
