### PR TITLE
Ingest pipe dlq alarm

### DIFF
--- a/infra/service-event-ingestion/monitor.tf
+++ b/infra/service-event-ingestion/monitor.tf
@@ -43,3 +43,40 @@ module "lambda_error_alarms" {
 
   alarm_actions = [local.error_alarm_target]
 }
+
+module "lambda_dlq_alarms" {
+  source  = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarms-by-multiple-dimensions"
+  version = "~> 3.0"
+
+  alarm_name          = "service_ingest_dlq_"
+  alarm_description   = "DLQ messages too high"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  threshold           = 1
+  period              = 60
+  unit                = "Count"
+
+  namespace   = "AWS/SQS"
+  metric_name = "NumberOfMessagesReceived"
+  statistic   = "Maximum"
+
+  dimensions = {
+    "wfm_sqs" = {
+      QueueName = "${local.wfm.function_name}_dlq"
+    },
+    "fqr_sqs" = {
+      QueueName = "${local.fqr.function_name}_dlq"
+    },
+    "srm_sc_sqs" = {
+      QueueName = "${local.srm.sc_function_name}_dlq"
+    },
+    "srm_llc_sqs" = {
+      QueueName = "${local.srm.llc_function_name}_dlq"
+    },
+    "mm_lib_sqs" = {
+      QueueName = "${local.mm.lib_function_name}_dlq"
+    }
+  }
+
+  alarm_actions = [local.error_alarm_target]
+}


### PR DESCRIPTION
- fix Lambda permissions to allow sqs:SendMessage to DLQ
- add CloudWatch alarms for DLQs

Note: if DLQ alarms work as intended we could retire the Lambda alarms