### PR TITLE
Implemented error mart em_library_dns table

### DIFF
--- a/orcavault/models/mart/error/_schema.yml
+++ b/orcavault/models/mart/error/_schema.yml
@@ -6,4 +6,7 @@ models:
     description: Listing of the Centre sequenced libray availability in OrcaBus services
 
   - name: em_library_aliases
-    description: Listing of the Centre sequenced libray aliases with run comments by lab team
+    description: Listing of the Centre sequenced libray aliases with run comments by the lab team
+
+  - name: em_library_dns
+    description: Listing of the Centre do not sequence (dns) libray with run comments by the lab team

--- a/orcavault/models/mart/error/em_library_dns.sql
+++ b/orcavault/models/mart/error/em_library_dns.sql
@@ -1,0 +1,119 @@
+{{
+    config(
+        indexes=[
+            {'columns': ['sheet_name'], 'type': 'btree'},
+            {'columns': ['run'], 'type': 'btree'},
+            {'columns': ['comments'], 'type': 'btree'},
+            {'columns': ['library_id'], 'type': 'btree'},
+            {'columns': ['alias_library_id'], 'type': 'btree'},
+            {'columns': ['internal_subject_id'], 'type': 'btree'},
+            {'columns': ['external_subject_id'], 'type': 'btree'},
+            {'columns': ['sample_id'], 'type': 'btree'},
+            {'columns': ['external_sample_id'], 'type': 'btree'},
+            {'columns': ['experiment_id'], 'type': 'btree'},
+            {'columns': ['project_id'], 'type': 'btree'},
+            {'columns': ['owner_id'], 'type': 'btree'},
+            {'columns': ['workflow'], 'type': 'btree'},
+            {'columns': ['phenotype'], 'type': 'btree'},
+            {'columns': ['type'], 'type': 'btree'},
+            {'columns': ['assay'], 'type': 'btree'},
+            {'columns': ['quality'], 'type': 'btree'},
+            {'columns': ['source'], 'type': 'btree'},
+            {'columns': ['load_datetime'], 'type': 'btree'},
+        ]
+    )
+}}
+
+with source as (
+
+    select
+        row_number() over (partition by library_id order by load_datetime desc) as rank,
+        *
+    from {{ ref('spreadsheet_library_tracking_metadata') }}
+
+),
+
+latest as (
+
+    select * from source where rank = 1
+
+),
+
+filtered as (
+
+    select * from latest where lower(run) like '%dns%' or lower(comments) like '%dns%'
+
+),
+
+aliased as (
+
+    select
+        src.*,
+        sal.base_library_id,
+        sal.alias_library_id
+    from
+        filtered src
+            left join {{ ref('sal_library') }} sal on sal.alias_library_id = src.library_id
+
+),
+
+transformed as (
+
+    select
+        sheet_name,
+        run,
+        comments,
+        coalesce(base_library_id, library_id) as library_id,
+        alias_library_id,
+        subject_id as internal_subject_id,
+        external_subject_id,
+        sample_id,
+        external_sample_id,
+        experiment_id,
+        project_name as project_id,
+        project_owner as owner_id,
+        workflow,
+        phenotype,
+        type,
+        assay,
+        quality,
+        source,
+        truseq_index,
+        record_source,
+        load_datetime
+    from
+        aliased
+
+),
+
+final as (
+
+    select
+        cast(sheet_name as varchar) as sheet_name,
+        cast(run as varchar) as run,
+        cast(comments as text) as comments,
+        cast(library_id as varchar(255)) as library_id,
+        cast(alias_library_id as varchar(255)) as alias_library_id,
+        cast(internal_subject_id as varchar(255)) as internal_subject_id,
+        cast(external_subject_id as varchar(255)) as external_subject_id,
+        cast(sample_id as varchar(255)) as sample_id,
+        cast(external_sample_id as varchar(255)) as external_sample_id,
+        cast(experiment_id as varchar(255)) as experiment_id,
+        cast(project_id as varchar(255)) as project_id,
+        cast(owner_id as varchar(255)) as owner_id,
+        cast(workflow as varchar(255)) as workflow,
+        cast(phenotype as varchar(255)) as phenotype,
+        cast(type as varchar(255)) as type,
+        cast(assay as varchar(255)) as assay,
+        cast(quality as varchar(255)) as quality,
+        cast(source as varchar(255)) as source,
+        cast(truseq_index as varchar(255)) as truseq_index,
+        cast(record_source as varchar(255)) as record_source,
+        cast(load_datetime as timestamptz) as load_datetime
+    from
+        transformed
+    order by sheet_name desc, library_id desc
+
+)
+
+select * from final

--- a/orcavault/seeds/dictionary/dictionary__data_mart_catalog.csv
+++ b/orcavault/seeds/dictionary/dictionary__data_mart_catalog.csv
@@ -7,7 +7,8 @@ workflow,Listing of the Centre genomic sequencing analysis workflow run details 
 accreditation_lims,Listing of the Centre genomic sequencing Accreditation LIMS metadata in flat table model,STABLE
 external_lims,Listing of the Externally sequenced LIMS metadata in flat table model,STABLE
 em_library_services,Listing of the Centre sequenced libray availability in OrcaBus services,STABLE
-em_library_aliases,Listing of the Centre sequenced libray aliases with run comments by lab team,STABLE
+em_library_aliases,Listing of the Centre sequenced libray aliases with run comments by the lab team,STABLE
+em_library_dns,Listing of the Centre do not sequence (dns) libray with run comments by the lab team,STABLE
 curation_lims,Listing of the Centre Curation Team LIMS metadata in flat table model,DEMO
 grimmond_lims,Listing of Grimmond Research Group LIMS metadata in flat table model,DEMO
 dawson_lims,Listing of Dawson Research Group LIMS metadata in flat table model,DEMO


### PR DESCRIPTION
* Story: Often the informatics team is puzzled by a library that did not
  make it to the sequencing. The lab team note these library as "dns"
  in the Library tracking sheet.

  Solution: The approach performs data mining on the sheet columns `run` and
  `comments`, then extract records and curate them into the em_library_dns table.

  The story fits to data warehouse Error Mart concept. To support informatics team
  on why sudden library are not found in the expected table location such as LIMS.
