### PR TITLE
Implemented data mart output model

### DIFF
--- a/orcavault/models/mart/centre/_schema.yml
+++ b/orcavault/models/mart/centre/_schema.yml
@@ -20,5 +20,8 @@ models:
   - name: workflow
     description: Listing of the Centre genomic sequencing analysis workflow run details in flat table model
 
+  - name: output
+    description: Listing of the Centre genomic sequencing analysis workflow run output location in flat table model
+
   - name: accreditation_lims
     description: Listing of the Centre genomic sequencing Accreditation LIMS metadata in flat table model

--- a/orcavault/models/mart/centre/output.sql
+++ b/orcavault/models/mart/centre/output.sql
@@ -1,0 +1,81 @@
+{{
+    config(
+        indexes=[
+            {'columns': ['portal_run_id'], 'type': 'btree'},
+            {'columns': ['cohort_id'], 'type': 'btree'},
+            {'columns': ['portal_run_id', 'cohort_id'], 'type': 'btree'},
+            {'columns': ['portal_run_id', 'bucket'], 'type': 'btree'},
+            {'columns': ['bucket'], 'type': 'btree'},
+            {'columns': ['prefix'], 'type': 'btree'},
+            {'columns': ['key_count'], 'type': 'btree'},
+        ]
+    )
+}}
+
+with location1 as (
+
+    select
+        sat.portal_run_id as portal_run_id,
+        hub.bucket as bucket,
+        min(regexp_substr(hub.key, '.*\d{8}\w{8}\/')) as prefix,
+        count(1) as key_count
+    from {{ ref('hub_s3object') }} hub
+        join {{ ref('sat_s3object_by_run') }} sat on sat.s3object_hk = hub.s3object_hk
+        join {{ ref('sat_s3object_current') }} hist on hist.s3object_hk = hub.s3object_hk
+    where
+        hist.is_current = 1 and
+        hist.is_deleted = 0
+    group by sat.portal_run_id, hub.bucket
+
+),
+
+location2 as (
+
+    select
+        sat.portal_run_id as portal_run_id,
+        hub.bucket as bucket,
+        min(regexp_substr(hub.key, '.*\d{8}\w{8}\/')) as prefix,
+        count(1) as key_count
+    from {{ ref('hub_s3object') }} hub
+        join {{ ref('sat_s3object_by_run') }} sat on sat.s3object_hk = hub.s3object_hk
+        join {{ ref('sat_s3object_portal') }} hist on hist.s3object_hk = hub.s3object_hk
+    where
+        hist.is_deleted = 0
+    group by sat.portal_run_id, hub.bucket
+
+),
+
+merged as (
+
+    select * from location1 union select * from location2
+
+),
+
+transformed as (
+
+    select
+        portal_run_id,
+        (regexp_match(prefix, '(?<=byob-icav2\/).+?(?=\/)'))[1] as cohort_id,
+        bucket,
+        prefix,
+        key_count
+    from
+        merged
+
+),
+
+final as (
+
+    select
+        cast(portal_run_id as char(16)) as portal_run_id,
+        cast(cohort_id as varchar(255)) as cohort_id,
+        cast(bucket as varchar(255)) as bucket,
+        cast(prefix as text) as prefix,
+        cast(key_count as bigint) as key_count
+    from
+        transformed
+    order by portal_run_id desc nulls last
+
+)
+
+select * from final

--- a/orcavault/seeds/dictionary/dictionary__data_mart_catalog.csv
+++ b/orcavault/seeds/dictionary/dictionary__data_mart_catalog.csv
@@ -4,6 +4,7 @@ fastq,Listing of the Centre genomic sequencing unaligned read level file FASTQ S
 fastq_history,Listing of the Centre genomic sequencing unaligned read level file FASTQ S3 historical locations,STABLE
 bam,Listing of the Centre genomic sequencing aligned read level file BAM and BAI S3 locations in flat table model,STABLE
 workflow,Listing of the Centre genomic sequencing analysis workflow run details in flat table model,STABLE
+output,Listing of the Centre genomic sequencing analysis workflow run output location in flat table model,STABLE
 accreditation_lims,Listing of the Centre genomic sequencing Accreditation LIMS metadata in flat table model,STABLE
 external_lims,Listing of the Externally sequenced LIMS metadata in flat table model,STABLE
 em_library_services,Listing of the Centre sequenced libray availability in OrcaBus services,STABLE


### PR DESCRIPTION
* The output model is listing of the Centre genomic sequencing analysis workflow
  run output location in a flat table model. It shows the S3 object store location
  prefix up to the `portal_run_id` in the path. The `key_count` shows an aggregated
  number of object counts found within this path. It is a natural extension of the
  workflow table.

  Use Case:
     select * from workflow join output on workflow.portal_run_id = output.portal_run_id
