### PR TITLE
Improved SequenceRunManager Link model tracking satellite to MAS

### DIFF
--- a/orcavault/models/dcl/sat_library_sequencing_run_srm.sql
+++ b/orcavault/models/dcl/sat_library_sequencing_run_srm.sql
@@ -47,6 +47,7 @@ final as (
 
     select
         cast(encode(sha256(concat(sequencing_run_hk, library_hk)::bytea), 'hex') as char(64)) as library_sequencing_run_hk,
+        cast(hash_diff as char(64)) as library_sequencing_run_sq,
         cast(load_datetime as timestamptz) as load_datetime,
         cast(record_source as varchar(255)) as record_source,
         cast(hash_diff as char(64)) as hash_diff,

--- a/orcavault/models/dcl/sat_schema.yml
+++ b/orcavault/models/dcl/sat_schema.yml
@@ -827,13 +827,15 @@ models:
       contract: { enforced: true }
     constraints:
       - type: primary_key
-        columns: [ library_sequencing_run_hk, load_datetime ]
+        columns: [ library_sequencing_run_hk, library_sequencing_run_sq, load_datetime ]
       - type: foreign_key
         columns: [ library_sequencing_run_hk ]
         to: ref('link_library_sequencing_run')
         to_columns: [ library_sequencing_run_hk ]
     columns:
       - name: library_sequencing_run_hk
+        data_type: char(64)
+      - name: library_sequencing_run_sq
         data_type: char(64)
       - name: load_datetime
         data_type: timestamptz


### PR DESCRIPTION
* The upstream SRM recent changes allow attaching a SampleSheet. This may happen
  within a day. In this case, linking between Hubs `hub_sequencing_run` and `hub_library`
  can happen within a single ETL loading window. This PR improves this Link model
  satellite tracker to accept multi-active records. Essentially, changing it to
  the Multi-Active Satellite (MAS) by adding a subsequence child-dependent field
  to the primary key (PK).
