### PR TITLE
Improved hub_s3object computed satellite incremental strategy

### DIFF
--- a/orcavault/models/dcl/sat_s3object_by_run.sql
+++ b/orcavault/models/dcl/sat_s3object_by_run.sql
@@ -12,7 +12,9 @@
             {'columns': ['hash_diff'], 'type': 'btree'},
         ],
         materialized='incremental',
-        incremental_strategy='append',
+        incremental_strategy='merge',
+        unique_key='hash_diff',
+        merge_update_columns=['filename', 'ext1', 'ext2', 'ext3'],
         on_schema_change='fail'
     )
 }}
@@ -61,7 +63,6 @@ final as (
 
     select
         cast(s3object_hk as char(64)) as s3object_hk,
-        cast(hash_diff as char(64)) as s3object_sq,
         cast(load_datetime as timestamptz) as load_datetime,
         cast(record_source as varchar(255)) as record_source,
         cast(hash_diff as char(64)) as hash_diff,

--- a/orcavault/models/dcl/sat_schema.yml
+++ b/orcavault/models/dcl/sat_schema.yml
@@ -655,15 +655,13 @@ models:
       contract: { enforced: true }
     constraints:
       - type: primary_key
-        columns: [ s3object_hk, s3object_sq, load_datetime ]
+        columns: [ s3object_hk, load_datetime ]
       - type: foreign_key
         columns: [ s3object_hk ]
         to: ref('hub_s3object')
         to_columns: [ s3object_hk ]
     columns:
       - name: s3object_hk
-        data_type: char(64)
-      - name: s3object_sq
         data_type: char(64)
       - name: load_datetime
         data_type: timestamptz


### PR DESCRIPTION
* Updated the incremental strategy to `merge` to align with its based Hub model
  hub_s3object. Typically, the computed satellite is in sync mode with its parent
  source hub model. Removed the `s3object_sq` column as well as from PK as it is
  found to be redundant for the computed satellite use case.
