### PR TITLE
Load variant monitoring events into PSA landing table

### DIFF
--- a/dev/src/psa.sql
+++ b/dev/src/psa.sql
@@ -147,6 +147,29 @@ CREATE TABLE IF NOT EXISTS orcavault.psa.event__workflow_run_state_change
     record_source       varchar(255)
 );
 
+CREATE TABLE IF NOT EXISTS orcavault.psa.event__variant_monitoring_result
+(
+    event_id                varchar,
+    event_time              varchar,
+    orcabus_id              varchar,
+    schema_version          varchar,
+    timestamp               varchar,
+    portal_run_id           varchar,
+    workflow_run_orcabus_id varchar,
+    workflow_name           varchar,
+    workflow_version        varchar,
+    library_id              varchar,
+    library_orcabus_id      varchar,
+    subject_id              varchar,
+    individual_id           varchar,
+    giab_id                 varchar,
+    analysis_name           varchar,
+    output_uri              varchar,
+    monitoring_sites        jsonb,
+    load_datetime           timestamptz,
+    record_source           varchar(255)
+);
+
 CREATE TABLE IF NOT EXISTS orcavault.psa.event__metadata_state_change_library
 (
     event_id                varchar,

--- a/dev/src/psa.sql
+++ b/dev/src/psa.sql
@@ -149,25 +149,21 @@ CREATE TABLE IF NOT EXISTS orcavault.psa.event__workflow_run_state_change
 
 CREATE TABLE IF NOT EXISTS orcavault.psa.event__variant_monitoring_result
 (
-    event_id                varchar,
-    event_time              varchar,
-    orcabus_id              varchar,
-    schema_version          varchar,
-    timestamp               varchar,
-    portal_run_id           varchar,
-    workflow_run_orcabus_id varchar,
-    workflow_name           varchar,
-    workflow_version        varchar,
-    library_id              varchar,
-    library_orcabus_id      varchar,
-    subject_id              varchar,
-    individual_id           varchar,
-    giab_id                 varchar,
-    analysis_name           varchar,
-    output_uri              varchar,
-    monitoring_sites        jsonb,
-    load_datetime           timestamptz,
-    record_source           varchar(255)
+    event_id        varchar,
+    event_time      varchar,
+    portal_run_id   varchar,
+    library_id      varchar,
+    chrom           varchar,
+    pos             integer,
+    ref             varchar,
+    alt             varchar,
+    dp              integer,
+    af              double precision,
+    filter_status   varchar,
+    variant_emitted boolean,
+    load_datetime   timestamptz,
+    record_source   varchar(255),
+    UNIQUE (portal_run_id, chrom, pos, ref, alt)
 );
 
 CREATE TABLE IF NOT EXISTS orcavault.psa.event__metadata_state_change_library

--- a/infra/service-event-ingestion/CHANGELOG.md
+++ b/infra/service-event-ingestion/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+All notable changes to the `service-event-ingestion` module are documented here.
+
+Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+
+---
+
+## [Unreleased]
+
+### Added — Variant Monitoring ingestion ([#212](https://github.com/umccr/orcahouse/issues/212))
+
+Adds a full ingestion pipeline for `VariantMonitoringResult` events emitted by
+[service-variant-monitoring](https://github.com/OrcaBus/service-variant-monitoring).
+
+**`dev/src/psa.sql`**
+- New table `orcavault.psa.event__variant_monitoring_result`.
+  Captures all fields from the `VariantMonitoringResult` event detail
+  ([schema](https://github.com/OrcaBus/service-variant-monitoring/blob/main/docs/events/VariantMonitoringResult/VariantMonitoringResult.schema.json)):
+  `portal_run_id`, `workflow_name`, `workflow_version`, `library_id`, `subject_id`,
+  `individual_id`, `giab_id`, `analysis_name`, `output_uri`.
+  The `monitoring_sites` array (per-site allele frequencies) is stored as `jsonb`.
+
+**`infra/service-event-ingestion/lambda/vm_event_handler/vm_event_handler.py`**
+- New Lambda handler. Validates `source = orcabus.variantmonitoring` and
+  `detail-type = VariantMonitoringResult`, flattens the payload, and inserts one row
+  into `psa.event__variant_monitoring_result`. Insert is idempotent on `event_id`.
+
+**`infra/service-event-ingestion/vm.tf`**
+- New Terraform file. Wires the `ingest_pipe` module for the Variant Monitoring event
+  pattern (`orcabus.variantmonitoring` / `VariantMonitoringResult`).
+
+**`infra/service-event-ingestion/monitor.tf`**
+- Added `vm_lambda` to the Lambda error alarm dimensions.
+- Added `vm_sqs` to the DLQ alarm dimensions.
+
+**`infra/service-event-ingestion/docs/service-guide.md`**
+- New service guide covering the end-to-end ingestion architecture, the PSA layer
+  conventions, and a step-by-step walkthrough for adding a new event type.
+
+---
+
+## Previous changes
+
+Changes prior to this changelog being introduced are tracked in the
+[git history](https://github.com/umccr/orcahouse/commits/main/infra/service-event-ingestion).

--- a/infra/service-event-ingestion/README.md
+++ b/infra/service-event-ingestion/README.md
@@ -3,15 +3,17 @@
 This is meant to handle events emitted by OrcaBus services and ingest them into the OrcaHouse Vault database.
 It's a kind of Change Data Capture (CDC) and allows the Vault to track changes in OrcaBus services.
 
-
 AWS infrastructure for default service ingestion pipeline
 
 ![Ingestion Pipeline](event-ingestion.drawio.svg)
 
-
-
-# Terraform
+## Terraform
 
 The ingestion pipelines are deployed using Terraform.
 
-TBC
+---
+
+For a detailed walkthrough of the architecture, how to add a new event type, and local
+testing instructions, see [docs/service-guide.md](docs/service-guide.md).
+
+For a history of changes, see [CHANGELOG.md](CHANGELOG.md).

--- a/infra/service-event-ingestion/docs/service-guide.md
+++ b/infra/service-event-ingestion/docs/service-guide.md
@@ -1,0 +1,322 @@
+# Service Event Ingestion — Service Guide
+
+This document describes the `service-event-ingestion` module for someone new to the
+OrcaHouse platform, Terraform, or event-driven architecture on AWS.
+
+## 1. What This Module Does
+
+OrcaBus services communicate by emitting events onto a shared AWS EventBridge bus
+(`OrcaBusMain`). This module captures those events and persists them into the OrcaHouse
+Vault PostgreSQL database.
+
+The pattern is a lightweight form of **Change Data Capture (CDC)**:
+
+- OrcaBus services are the source of truth for operational data.
+- OrcaHouse is the analytical warehouse that needs a historical record of those events.
+- This module is the bridge between them.
+
+Each event type has its own Lambda function that:
+
+1. Receives the event from EventBridge.
+2. Extracts and flattens the fields.
+3. Inserts one row into a PSA landing table in the database.
+
+## 2. The Big Picture
+
+```text
+OrcaBus service (e.g. Workflow Manager)
+  -> emits an event onto OrcaBusMain EventBridge bus
+  -> EventBridge rule filters by source + detail-type
+  -> Lambda function is invoked
+  -> Lambda flattens the event payload
+  -> Lambda inserts one row into the PSA table in OrcaVault (PostgreSQL)
+  -> SQS Dead Letter Queue (DLQ) catches any failed invocations
+```
+
+The database insert is idempotent: if the same `event_id` is received twice, the second
+insert is silently skipped (`WHERE NOT EXISTS`).
+
+## 3. The PSA Layer
+
+PSA stands for **Persistent Staging Area**. It is the data landing zone inside the
+OrcaHouse Vault database.
+
+PSA tables follow these conventions:
+
+- All columns are `varchar` (or `jsonb` for nested structures).
+- Every table carries `load_datetime` (when the row was inserted) and `record_source`
+  (which service and event type produced it).
+- Tables are named after the event they capture, e.g. `event__workflow_run_state_change`.
+- There is no transformation at this layer — data is stored as received.
+
+Downstream layers (ODS, TSA) apply business logic on top of the PSA data.
+
+The PSA schema is defined in [dev/src/psa.sql](../../../dev/src/psa.sql).
+
+## 4. Events Ingested
+
+| Service | Event type | PSA table | Terraform file |
+|---|---|---|---|
+| Workflow Manager | `WorkflowRunStateChange` | `event__workflow_run_state_change` | `wfr.tf` |
+| FASTQ Manager | `FastqStateChange` | `event__fastq_list_row_state_change` | `fqr.tf` |
+| Sequence Run Manager | `SequenceRunStateChange` | `event__sequence_run_state_change` | `srm.tf` |
+| Sequence Run Manager | `SequenceRunLibraryLinkingChange` | `event__sequence_run_library_linking_change` | `srm.tf` |
+| Metadata Manager | `MetadataStateChange` | `event__metadata_state_change_library` | `mm.tf` |
+| Variant Monitoring | `VariantMonitoringResult` | `event__variant_monitoring_result` | `vm.tf` |
+
+## 5. AWS Resources Created Per Event Type
+
+Each call to the `ingest_pipe` Terraform module (in `infra/common/ingest_pipe/`)
+creates the following AWS resources:
+
+### EventBridge rule
+
+Listens to the `OrcaBusMain` event bus and filters by `source` + `detail-type`.
+Only matching events are forwarded to the Lambda. No Lambda cold starts for unrelated
+events.
+
+### Lambda function
+
+- Runtime: Python 3.13
+- Packaged with `psycopg2` from a shared Lambda layer.
+- Runs inside the VPC to reach the private OrcaVault RDS cluster.
+- Environment variable `DB_SECRET_NAME` points to the Secrets Manager secret holding
+  the database credentials.
+
+### SQS Dead Letter Queue (DLQ)
+
+If the Lambda fails (e.g. a malformed event, a transient DB error), the event is
+moved to the DLQ after the configured retries. CloudWatch alarms monitor DLQ depth.
+
+### IAM policies
+
+- Read access to the Secrets Manager secret.
+- Permission to send failed messages to the DLQ.
+- VPC network interface access (required for Lambda-in-VPC).
+
+### CloudWatch alarms
+
+Defined in `monitor.tf`. Two alarm types cover all Lambda functions:
+
+- **Error alarm** — fires when Lambda error count ≥ 1 in a 60-second period.
+- **DLQ alarm** — fires when the DLQ receives ≥ 1 message.
+
+Both alarms notify via the shared SNS → Chatbot → Slack pipeline.
+
+## 6. Repository Structure
+
+```text
+infra/service-event-ingestion/
+├── main.tf               # Provider, VPC data, Secrets Manager, psycopg2 Lambda layer
+├── variables.tf          # Input variables (db_secret_name, vpc_tags)
+├── monitor.tf            # CloudWatch alarms for all Lambda functions and DLQs
+├── fqr.tf                # FASTQ Manager ingestion pipe
+├── mm.tf                 # Metadata Manager ingestion pipe
+├── srm.tf                # Sequence Run Manager ingestion pipes (two event types)
+├── vm.tf                 # Variant Monitoring ingestion pipe
+├── wfr.tf                # Workflow Manager ingestion pipe
+├── lambda/
+│   ├── utils/
+│   │   └── utils.py      # Shared helpers: get_secret, get_db_connection, push_to_db
+│   ├── fqr_event_handler/
+│   │   └── fqr_event_handler.py
+│   ├── mm_lib_event_handler/
+│   │   └── mm_lib_event_handler.py
+│   ├── srm_llc_event_handler/
+│   │   └── srm_llc_event_handler.py
+│   ├── srm_sc_event_handler/
+│   │   └── srm_sc_event_handler.py
+│   ├── vm_event_handler/
+│   │   ├── vm_event_handler.py
+│   │   └── test_local.py
+│   └── wfm_event_handler/
+│       └── wfm_event_handler.py
+└── docs/
+    └── service-guide.md  # This file
+```
+
+The shared `ingest_pipe` Terraform module lives in:
+
+```text
+infra/common/ingest_pipe/
+├── main.tf       # Lambda, DLQ, IAM, EventBridge rule and target
+└── variables.tf  # Module inputs
+```
+
+## 7. How a Lambda Handler Works
+
+All handlers follow the same pattern. Using `vm_event_handler.py` as the example:
+
+### Module-level initialisation
+
+```python
+DB_SECRET_NAME = os.environ["DB_SECRET_NAME"]
+DB_CREDENTIALS = utils.get_secret(DB_SECRET_NAME, secretsmanager_client)
+DB_CONNECTION = utils.get_db_connection(DB_CREDENTIALS)
+```
+
+The DB connection is established once when the Lambda container starts (cold start),
+then reused across invocations. This avoids opening a new connection on every event.
+
+### `handler(event, context)`
+
+The Lambda entrypoint. Calls `parse_event` then `push_to_db`.
+
+### `parse_event(event)`
+
+Validates `detail-type` and `source`, then extracts the fields into a flat dictionary
+whose keys match the PSA table columns. Nested objects (e.g. `monitoringSites`) are
+serialised with `json.dumps`.
+
+### `push_to_db(conn, sql, data)`
+
+Defined in `utils.py`. Builds the parameterised INSERT from the dictionary keys and
+executes it. The `WHERE NOT EXISTS` guard prevents duplicate rows.
+
+## 8. How to Add a New Event Type
+
+Follow these four steps (the Variant Monitoring handler is the worked example).
+
+### Step 1 — Define the PSA table
+
+Add a `CREATE TABLE IF NOT EXISTS` block to [dev/src/psa.sql](../../../dev/src/psa.sql).
+
+Conventions:
+- Table name: `event__<service>_<event_type>` in snake_case.
+- All data columns: `varchar`.
+- Nested/array fields: `jsonb`.
+- Always include `event_id varchar`, `event_time varchar`, `load_datetime timestamptz`,
+  `record_source varchar(255)`.
+
+### Step 2 — Write the Lambda handler
+
+Create `lambda/<name>_event_handler/<name>_event_handler.py`.
+
+Copy the structure from an existing handler (e.g. `vm_event_handler.py`) and set:
+
+```python
+TABLE_NAME = "event__<your_table>"
+DETAIL_TYPE = "<YourEventDetailType>"
+EVENT_SOURCE = "orcabus.<yourservice>"
+```
+
+Implement `parse_event` to extract the fields from the EventBridge envelope into a
+flat dict that maps to your table columns.
+
+### Step 3 — Add the Terraform module call
+
+Create `<service_abbreviation>.tf`:
+
+```hcl
+locals {
+  <abbr> = {
+    function_name = "<name>_event_handler"
+  }
+}
+
+module "<abbr>_result" {
+  source = "../common/ingest_pipe"
+
+  service_id     = "<ABBR>"
+  iam_path       = "/orcavault/serviceingestion/<abbr>/"
+  db_secret_name = var.db_secret_name
+
+  event_pattern = {
+    detail-type = ["<YourEventDetailType>"]
+    source      = ["orcabus.<yourservice>"]
+  }
+
+  lambda_function_name     = local.<abbr>.function_name
+  lambda_function_handler  = "${local.<abbr>.function_name}.handler"
+  lambda_source_paths      = [
+    "lambda/${local.<abbr>.function_name}",
+    "lambda/utils/utils.py"
+  ]
+  lambda_artefact_out_path = ".temp/lambda/${local.<abbr>.function_name}.zip"
+  lambda_layers            = [aws_lambda_layer_version.psycopg2_layer.arn]
+}
+```
+
+### Step 4 — Add CloudWatch alarms
+
+In `monitor.tf`, add entries for the new Lambda to both alarm dimensions blocks:
+
+```hcl
+# in module "lambda_error_alarms"
+"<abbr>_lambda" = {
+  FunctionName = local.<abbr>.function_name
+}
+
+# in module "lambda_dlq_alarms"
+"<abbr>_sqs" = {
+  QueueName = "${local.<abbr>.function_name}_dlq"
+}
+```
+
+## 9. Local Testing
+
+A local PostgreSQL instance is available via Docker Compose in `dev/`.
+
+### Start the database and create the PSA tables
+
+```bash
+cd dev
+make up    # starts Postgres on localhost:5432
+make psa   # runs psa.sql to create all PSA tables
+```
+
+### Run the handler test script
+
+Each handler directory can contain a `test_local.py` script.
+
+For the Variant Monitoring handler:
+
+```bash
+cd infra/service-event-ingestion/lambda/vm_event_handler
+pip install psycopg2-binary
+python test_local.py
+```
+
+The script patches out the AWS SDK calls (Secrets Manager) and connects directly
+to the local Postgres. It runs three checks:
+
+1. `test_parse_event` — asserts all fields are extracted correctly.
+2. `test_db_insert` — inserts the parsed event and reads the row back.
+3. `test_duplicate_insert` — verifies the idempotency guard keeps the count at 1.
+
+### Connect to the local database directly
+
+```bash
+cd dev
+make psql
+# then in psql:
+SELECT * FROM psa.event__variant_monitoring_result LIMIT 5;
+```
+
+## 10. Deployment
+
+The module is deployed with Terraform.
+
+```bash
+cd infra/service-event-ingestion
+terraform init
+terraform workspace select <env>   # e.g. prod
+terraform plan
+terraform apply
+```
+
+After applying, run the PSA DDL against the target database to create any new tables
+added to `psa.sql`.
+
+## 11. Short Glossary
+
+| Term | Meaning |
+|---|---|
+| CDC | Change Data Capture — capturing every state change in a source system |
+| PSA | Persistent Staging Area — the raw landing zone in the warehouse |
+| ODS | Operational Data Store — lightly transformed layer above PSA |
+| EventBridge | AWS service that routes events between producers and consumers |
+| DLQ | Dead Letter Queue — holds events that Lambda failed to process |
+| ingest_pipe | Reusable Terraform module that wires EventBridge → Lambda → DLQ |
+| OrcaBusMain | The shared EventBridge bus used by all OrcaBus platform services |
+| record_source | Column tracking which service and event type produced each PSA row |

--- a/infra/service-event-ingestion/lambda/vm_event_handler/test_local.py
+++ b/infra/service-event-ingestion/lambda/vm_event_handler/test_local.py
@@ -2,12 +2,11 @@
 Local integration test for vm_event_handler.
 Requires the dev Postgres to be running: cd dev && make up && make psa
 """
-import json
 import sys
 import os
+import math
 from unittest.mock import MagicMock, patch
 
-# Patch module-level AWS/DB calls so the import doesn't fail without AWS
 os.environ.setdefault("DB_SECRET_NAME", "test-secret")
 
 _mock_utils = MagicMock()
@@ -20,7 +19,6 @@ with patch.dict("sys.modules", {"utils": _mock_utils}), \
     sys.path.insert(0, os.path.dirname(__file__))
     import vm_event_handler
 
-import psycopg2
 from psycopg2.extras import RealDictCursor
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../utils"))
@@ -59,16 +57,8 @@ SAMPLE_EVENT = {
         "analysisName": "umccr--automated--dragen-wgts-dna--4-3-6--20250416abcdef01",
         "outputUri": "s3://pipeline-dev-cache-xxx/byob-icav2/.../dragen-wgts-dna/20250416abcdef01/",
         "monitoringSites": [
-            {
-                "chrom": "chr1",
-                "pos": 100000,
-                "ref": "A",
-                "alt": "T",
-                "dp": 45,
-                "af": 0.489,
-                "filter_status": "PASS",
-                "variant_emitted": True,
-            }
+            {"chrom": "chr1", "pos": 100000, "ref": "A", "alt": "T", "dp": 45, "af": 0.489, "filter_status": "PASS", "variant_emitted": True},
+            {"chrom": "chr7", "pos": 55259515, "ref": "G", "alt": "A", "dp": 38, "af": 0.012, "filter_status": "PASS", "variant_emitted": False},
         ],
     },
 }
@@ -88,12 +78,14 @@ def cleanup(conn, event_id):
 
 
 def test_parse_event():
-    data = vm_event_handler.parse_event(SAMPLE_EVENT)
-    assert data["event_id"] == "test-event-id-local-001"
-    assert data["library_id"] == "L2401538"
-    assert data["workflow_name"] == "dragen-wgts-dna"
-    sites = json.loads(data["monitoring_sites"])
-    assert sites[0]["chrom"] == "chr1"
+    rows = vm_event_handler.parse_event(SAMPLE_EVENT)
+    assert len(rows) == 2
+    assert rows[0]["chrom"] == "chr1"
+    assert rows[0]["pos"] == 100000
+    assert math.isclose(rows[0]["af"], 0.489)
+    assert rows[0]["variant_emitted"] is True
+    assert rows[1]["chrom"] == "chr7"
+    assert rows[1]["variant_emitted"] is False
     print("  PASS test_parse_event")
 
 
@@ -101,22 +93,26 @@ def test_db_insert():
     conn = get_conn()
     cleanup(conn, SAMPLE_EVENT["id"])
 
-    data = vm_event_handler.parse_event(SAMPLE_EVENT)
-    real_utils.push_to_db(conn, vm_event_handler.SQL_INSERT, data)
+    rows = vm_event_handler.parse_event(SAMPLE_EVENT)
+    for row in rows:
+        vm_event_handler._insert_row(conn, row)
 
     with conn.cursor(cursor_factory=RealDictCursor) as cur:
         cur.execute(
-            "SELECT * FROM psa.event__variant_monitoring_result WHERE event_id = %s",
+            "SELECT * FROM psa.event__variant_monitoring_result WHERE event_id = %s ORDER BY chrom",
             (SAMPLE_EVENT["id"],),
         )
-        rows = cur.fetchall()
+        result = cur.fetchall()
 
-    assert len(rows) == 1
-    row = rows[0]
-    assert row["library_id"] == "L2401538"
-    assert row["record_source"] == "orcabus.variantmonitoring:VariantMonitoringResult"
-    sites = row["monitoring_sites"]  # jsonb is already deserialised by psycopg2
-    assert sites[0]["chrom"] == "chr1"
+    assert len(result) == 2
+    assert result[0]["chrom"] == "chr1"
+    assert result[0]["pos"] == 100000
+    assert result[0]["variant_emitted"] is True
+    assert result[0]["portal_run_id"] == "20250416abcdef01"
+    assert result[0]["library_id"] == "L2401538"
+    assert result[0]["record_source"] == "orcabus.variantmonitoring:VariantMonitoringResult"
+    assert result[1]["chrom"] == "chr7"
+    assert result[1]["variant_emitted"] is False
     print("  PASS test_db_insert")
     conn.close()
 
@@ -125,9 +121,11 @@ def test_duplicate_insert():
     conn = get_conn()
     cleanup(conn, SAMPLE_EVENT["id"])
 
-    data = vm_event_handler.parse_event(SAMPLE_EVENT)
-    real_utils.push_to_db(conn, vm_event_handler.SQL_INSERT, data)
-    real_utils.push_to_db(conn, vm_event_handler.SQL_INSERT, data)
+    rows = vm_event_handler.parse_event(SAMPLE_EVENT)
+    for row in rows:
+        vm_event_handler._insert_row(conn, row)
+    for row in rows:
+        vm_event_handler._insert_row(conn, row)
 
     with conn.cursor() as cur:
         cur.execute(
@@ -136,9 +134,97 @@ def test_duplicate_insert():
         )
         count = cur.fetchone()[0]
 
-    assert count == 1, f"Expected 1 row but got {count}"
+    assert count == 2, f"Expected 2 rows (one per site) but got {count}"
     print("  PASS test_duplicate_insert")
     cleanup(conn, SAMPLE_EVENT["id"])
+    conn.close()
+
+
+def test_two_events_same_site_coordinates():
+    event_a = {**SAMPLE_EVENT, "id": "test-event-id-local-002"}
+    event_b = {
+        **SAMPLE_EVENT,
+        "id": "test-event-id-local-003",
+        "detail": {**SAMPLE_EVENT["detail"], "portalRunId": "20250417abcdef02"},
+    }
+    conn = get_conn()
+    cleanup(conn, event_a["id"])
+    cleanup(conn, event_b["id"])
+
+    for row in vm_event_handler.parse_event(event_a):
+        vm_event_handler._insert_row(conn, row)
+    for row in vm_event_handler.parse_event(event_b):
+        vm_event_handler._insert_row(conn, row)
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM psa.event__variant_monitoring_result WHERE event_id IN (%s, %s)",
+            (event_a["id"], event_b["id"]),
+        )
+        count = cur.fetchone()[0]
+
+    assert count == 4, f"Expected 4 rows (2 sites x 2 events) but got {count}"
+    print("  PASS test_two_events_same_site_coordinates")
+    cleanup(conn, event_a["id"])
+    cleanup(conn, event_b["id"])
+    conn.close()
+
+
+def test_site_with_missing_optional_fields():
+    event = {
+        **SAMPLE_EVENT,
+        "id": "test-event-id-local-004",
+        "detail": {
+            **SAMPLE_EVENT["detail"],
+            "monitoringSites": [
+                {"chrom": "chr1", "pos": 100000, "ref": "A", "alt": "T", "variant_emitted": False},
+            ],
+        },
+    }
+    conn = get_conn()
+    cleanup(conn, event["id"])
+
+    rows = vm_event_handler.parse_event(event)
+    for row in rows:
+        vm_event_handler._insert_row(conn, row)
+
+    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(
+            "SELECT * FROM psa.event__variant_monitoring_result WHERE event_id = %s",
+            (event["id"],),
+        )
+        result = cur.fetchone()
+
+    assert result["chrom"] == "chr1"
+    assert result["dp"] is None
+    assert result["af"] is None
+    print("  PASS test_site_with_missing_optional_fields")
+    cleanup(conn, event["id"])
+    conn.close()
+
+
+def test_empty_monitoring_sites_inserts_nothing():
+    event = {
+        **SAMPLE_EVENT,
+        "id": "test-event-id-local-005",
+        "detail": {**SAMPLE_EVENT["detail"], "monitoringSites": []},
+    }
+    conn = get_conn()
+    cleanup(conn, event["id"])
+
+    rows = vm_event_handler.parse_event(event)
+    for row in rows:
+        vm_event_handler._insert_row(conn, row)
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM psa.event__variant_monitoring_result WHERE event_id = %s",
+            (event["id"],),
+        )
+        count = cur.fetchone()[0]
+
+    assert count == 0, f"Expected 0 rows for empty sites but got {count}"
+    print("  PASS test_empty_monitoring_sites_inserts_nothing")
     conn.close()
 
 
@@ -147,4 +233,7 @@ if __name__ == "__main__":
     test_parse_event()
     test_db_insert()
     test_duplicate_insert()
+    test_two_events_same_site_coordinates()
+    test_site_with_missing_optional_fields()
+    test_empty_monitoring_sites_inserts_nothing()
     print("All tests passed.")

--- a/infra/service-event-ingestion/lambda/vm_event_handler/test_local.py
+++ b/infra/service-event-ingestion/lambda/vm_event_handler/test_local.py
@@ -1,0 +1,150 @@
+"""
+Local integration test for vm_event_handler.
+Requires the dev Postgres to be running: cd dev && make up && make psa
+"""
+import json
+import sys
+import os
+from unittest.mock import MagicMock, patch
+
+# Patch module-level AWS/DB calls so the import doesn't fail without AWS
+os.environ.setdefault("DB_SECRET_NAME", "test-secret")
+
+_mock_utils = MagicMock()
+_mock_utils.get_secret.return_value = {}
+_mock_utils.get_db_connection.return_value = MagicMock()
+
+with patch.dict("sys.modules", {"utils": _mock_utils}), \
+     patch("boto3.client", return_value=MagicMock()), \
+     patch("boto3.session.Session", return_value=MagicMock()):
+    sys.path.insert(0, os.path.dirname(__file__))
+    import vm_event_handler
+
+import psycopg2
+from psycopg2.extras import RealDictCursor
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../utils"))
+import utils as real_utils
+
+DB_CREDENTIALS = {
+    "host": "localhost",
+    "port": 5432,
+    "dbname": "orcavault",
+    "username": "dev",
+    "password": "dev",  # pragma: allowlist-secret
+}
+
+SAMPLE_EVENT = {
+    "version": "0",
+    "id": "test-event-id-local-001",
+    "detail-type": "VariantMonitoringResult",
+    "source": "orcabus.variantmonitoring",
+    "account": "472057503814",
+    "time": "2025-04-16T10:00:00Z",
+    "region": "ap-southeast-2",
+    "resources": [],
+    "detail": {
+        "id": "d41d8cd98f00b204e9800998ecf8427e",
+        "version": "0.1.0",
+        "timestamp": "2025-04-16T10:00:00+00:00",
+        "portalRunId": "20250416abcdef01",
+        "workflowRunOrcabusId": "wfr.01JXXXXX",
+        "workflowName": "dragen-wgts-dna",
+        "workflowVersion": "4.3.6",
+        "libraryId": "L2401538",
+        "libraryOrcabusId": "lib.01JXXXXX",
+        "subjectId": "SBJ00001",
+        "individualId": "NA12878",
+        "giabId": "HG001",
+        "analysisName": "umccr--automated--dragen-wgts-dna--4-3-6--20250416abcdef01",
+        "outputUri": "s3://pipeline-dev-cache-xxx/byob-icav2/.../dragen-wgts-dna/20250416abcdef01/",
+        "monitoringSites": [
+            {
+                "chrom": "chr1",
+                "pos": 100000,
+                "ref": "A",
+                "alt": "T",
+                "dp": 45,
+                "af": 0.489,
+                "filter_status": "PASS",
+                "variant_emitted": True,
+            }
+        ],
+    },
+}
+
+
+def get_conn():
+    return real_utils.get_db_connection(DB_CREDENTIALS)
+
+
+def cleanup(conn, event_id):
+    with conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM psa.event__variant_monitoring_result WHERE event_id = %s",
+                (event_id,),
+            )
+
+
+def test_parse_event():
+    data = vm_event_handler.parse_event(SAMPLE_EVENT)
+    assert data["event_id"] == "test-event-id-local-001"
+    assert data["library_id"] == "L2401538"
+    assert data["workflow_name"] == "dragen-wgts-dna"
+    sites = json.loads(data["monitoring_sites"])
+    assert sites[0]["chrom"] == "chr1"
+    print("  PASS test_parse_event")
+
+
+def test_db_insert():
+    conn = get_conn()
+    cleanup(conn, SAMPLE_EVENT["id"])
+
+    data = vm_event_handler.parse_event(SAMPLE_EVENT)
+    real_utils.push_to_db(conn, vm_event_handler.SQL_INSERT, data)
+
+    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(
+            "SELECT * FROM psa.event__variant_monitoring_result WHERE event_id = %s",
+            (SAMPLE_EVENT["id"],),
+        )
+        rows = cur.fetchall()
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["library_id"] == "L2401538"
+    assert row["record_source"] == "orcabus.variantmonitoring:VariantMonitoringResult"
+    sites = row["monitoring_sites"]  # jsonb is already deserialised by psycopg2
+    assert sites[0]["chrom"] == "chr1"
+    print("  PASS test_db_insert")
+    conn.close()
+
+
+def test_duplicate_insert():
+    conn = get_conn()
+    cleanup(conn, SAMPLE_EVENT["id"])
+
+    data = vm_event_handler.parse_event(SAMPLE_EVENT)
+    real_utils.push_to_db(conn, vm_event_handler.SQL_INSERT, data)
+    real_utils.push_to_db(conn, vm_event_handler.SQL_INSERT, data)
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM psa.event__variant_monitoring_result WHERE event_id = %s",
+            (SAMPLE_EVENT["id"],),
+        )
+        count = cur.fetchone()[0]
+
+    assert count == 1, f"Expected 1 row but got {count}"
+    print("  PASS test_duplicate_insert")
+    cleanup(conn, SAMPLE_EVENT["id"])
+    conn.close()
+
+
+if __name__ == "__main__":
+    print("Running local integration tests for vm_event_handler...")
+    test_parse_event()
+    test_db_insert()
+    test_duplicate_insert()
+    print("All tests passed.")

--- a/infra/service-event-ingestion/lambda/vm_event_handler/test_vm_event_handler.py
+++ b/infra/service-event-ingestion/lambda/vm_event_handler/test_vm_event_handler.py
@@ -1,0 +1,114 @@
+import json
+import sys
+import os
+from unittest.mock import MagicMock, patch
+
+# Patch module-level AWS/DB calls before import
+os.environ.setdefault("DB_SECRET_NAME", "test-secret")
+
+with patch.dict("sys.modules", {"utils": MagicMock()}), \
+     patch("boto3.client", return_value=MagicMock()), \
+     patch("boto3.session.Session", return_value=MagicMock()):
+    sys.path.insert(0, os.path.dirname(__file__))
+    import vm_event_handler
+
+import pytest
+
+SAMPLE_EVENT = {
+    "version": "0",
+    "id": "abc123",
+    "detail-type": "VariantMonitoringResult",
+    "source": "orcabus.variantmonitoring",
+    "account": "472057503814",
+    "time": "2025-04-16T10:00:00Z",
+    "region": "ap-southeast-2",
+    "resources": [],
+    "detail": {
+        "id": "d41d8cd98f00b204e9800998ecf8427e",
+        "version": "0.1.0",
+        "timestamp": "2025-04-16T10:00:00+00:00",
+        "portalRunId": "20250416abcdef01",
+        "workflowRunOrcabusId": "wfr.01JXXXXX",
+        "workflowName": "dragen-wgts-dna",
+        "workflowVersion": "4.3.6",
+        "libraryId": "L2401538",
+        "libraryOrcabusId": "lib.01JXXXXX",
+        "subjectId": "SBJ00001",
+        "individualId": "NA12878",
+        "giabId": "HG001",
+        "analysisName": "umccr--automated--dragen-wgts-dna--4-3-6--20250416abcdef01",
+        "outputUri": "s3://pipeline-dev-cache-xxx/byob-icav2/.../dragen-wgts-dna/20250416abcdef01/",
+        "monitoringSites": [
+            {
+                "chrom": "chr1",
+                "pos": 100000,
+                "ref": "A",
+                "alt": "T",
+                "dp": 45,
+                "af": 0.489,
+                "filter_status": "PASS",
+                "variant_emitted": True,
+            }
+        ],
+    },
+}
+
+
+def test_parse_event_happy_path():
+    data = vm_event_handler.parse_event(SAMPLE_EVENT)
+
+    assert data["event_id"] == "abc123"
+    assert data["event_time"] == "2025-04-16T10:00:00Z"
+    assert data["orcabus_id"] == "d41d8cd98f00b204e9800998ecf8427e"
+    assert data["schema_version"] == "0.1.0"
+    assert data["timestamp"] == "2025-04-16T10:00:00+00:00"
+    assert data["portal_run_id"] == "20250416abcdef01"
+    assert data["workflow_run_orcabus_id"] == "wfr.01JXXXXX"
+    assert data["workflow_name"] == "dragen-wgts-dna"
+    assert data["workflow_version"] == "4.3.6"
+    assert data["library_id"] == "L2401538"
+    assert data["library_orcabus_id"] == "lib.01JXXXXX"
+    assert data["subject_id"] == "SBJ00001"
+    assert data["individual_id"] == "NA12878"
+    assert data["giab_id"] == "HG001"
+    assert data["analysis_name"] == "umccr--automated--dragen-wgts-dna--4-3-6--20250416abcdef01"
+    assert data["output_uri"].startswith("s3://")
+    assert data["record_source"] == "orcabus.variantmonitoring:VariantMonitoringResult"
+
+
+def test_parse_event_monitoring_sites_serialised_as_json():
+    data = vm_event_handler.parse_event(SAMPLE_EVENT)
+    sites = json.loads(data["monitoring_sites"])
+    assert isinstance(sites, list)
+    assert sites[0]["chrom"] == "chr1"
+    assert sites[0]["af"] == 0.489
+
+
+def test_parse_event_empty_monitoring_sites():
+    event = {**SAMPLE_EVENT, "detail": {**SAMPLE_EVENT["detail"], "monitoringSites": []}}
+    data = vm_event_handler.parse_event(event)
+    assert json.loads(data["monitoring_sites"]) == []
+
+
+def test_parse_event_wrong_detail_type():
+    event = {**SAMPLE_EVENT, "detail-type": "SomethingElse"}
+    with pytest.raises(ValueError, match="Invalid event type"):
+        vm_event_handler.parse_event(event)
+
+
+def test_parse_event_wrong_source():
+    event = {**SAMPLE_EVENT, "source": "orcabus.other"}
+    with pytest.raises(ValueError, match="Invalid event source"):
+        vm_event_handler.parse_event(event)
+
+
+def test_parse_event_missing_optional_fields():
+    detail = {
+        "id": "minimalid",
+        "version": "0.1.0",
+    }
+    event = {**SAMPLE_EVENT, "detail": detail}
+    data = vm_event_handler.parse_event(event)
+    assert data["orcabus_id"] == "minimalid"
+    assert data["portal_run_id"] == ""
+    assert data["monitoring_sites"] == "[]"

--- a/infra/service-event-ingestion/lambda/vm_event_handler/test_vm_event_handler.py
+++ b/infra/service-event-ingestion/lambda/vm_event_handler/test_vm_event_handler.py
@@ -1,9 +1,7 @@
-import json
 import sys
 import os
 from unittest.mock import MagicMock, patch
 
-# Patch module-level AWS/DB calls before import
 os.environ.setdefault("DB_SECRET_NAME", "test-secret")
 
 with patch.dict("sys.modules", {"utils": MagicMock()}), \
@@ -39,55 +37,58 @@ SAMPLE_EVENT = {
         "analysisName": "umccr--automated--dragen-wgts-dna--4-3-6--20250416abcdef01",
         "outputUri": "s3://pipeline-dev-cache-xxx/byob-icav2/.../dragen-wgts-dna/20250416abcdef01/",
         "monitoringSites": [
-            {
-                "chrom": "chr1",
-                "pos": 100000,
-                "ref": "A",
-                "alt": "T",
-                "dp": 45,
-                "af": 0.489,
-                "filter_status": "PASS",
-                "variant_emitted": True,
-            }
+            {"chrom": "chr1", "pos": 100000, "ref": "A", "alt": "T", "dp": 45, "af": 0.489, "filter_status": "PASS", "variant_emitted": True},
+            {"chrom": "chr7", "pos": 55259515, "ref": "G", "alt": "A", "dp": 38, "af": 0.012, "filter_status": "PASS", "variant_emitted": False},
         ],
     },
 }
 
 
-def test_parse_event_happy_path():
-    data = vm_event_handler.parse_event(SAMPLE_EVENT)
-
-    assert data["event_id"] == "abc123"
-    assert data["event_time"] == "2025-04-16T10:00:00Z"
-    assert data["orcabus_id"] == "d41d8cd98f00b204e9800998ecf8427e"
-    assert data["schema_version"] == "0.1.0"
-    assert data["timestamp"] == "2025-04-16T10:00:00+00:00"
-    assert data["portal_run_id"] == "20250416abcdef01"
-    assert data["workflow_run_orcabus_id"] == "wfr.01JXXXXX"
-    assert data["workflow_name"] == "dragen-wgts-dna"
-    assert data["workflow_version"] == "4.3.6"
-    assert data["library_id"] == "L2401538"
-    assert data["library_orcabus_id"] == "lib.01JXXXXX"
-    assert data["subject_id"] == "SBJ00001"
-    assert data["individual_id"] == "NA12878"
-    assert data["giab_id"] == "HG001"
-    assert data["analysis_name"] == "umccr--automated--dragen-wgts-dna--4-3-6--20250416abcdef01"
-    assert data["output_uri"].startswith("s3://")
-    assert data["record_source"] == "orcabus.variantmonitoring:VariantMonitoringResult"
+def test_parse_event_returns_one_row_per_site():
+    rows = vm_event_handler.parse_event(SAMPLE_EVENT)
+    assert len(rows) == 2
 
 
-def test_parse_event_monitoring_sites_serialised_as_json():
-    data = vm_event_handler.parse_event(SAMPLE_EVENT)
-    sites = json.loads(data["monitoring_sites"])
-    assert isinstance(sites, list)
-    assert sites[0]["chrom"] == "chr1"
-    assert sites[0]["af"] == 0.489
+def test_parse_event_only_contains_expected_columns():
+    rows = vm_event_handler.parse_event(SAMPLE_EVENT)
+    expected_keys = {
+        "event_id", "event_time", "portal_run_id", "library_id",
+        "chrom", "pos", "ref", "alt", "dp", "af",
+        "filter_status", "variant_emitted", "load_datetime", "record_source",
+    }
+    assert set(rows[0].keys()) == expected_keys
 
 
-def test_parse_event_empty_monitoring_sites():
+def test_parse_event_event_fields_repeated_on_every_row():
+    rows = vm_event_handler.parse_event(SAMPLE_EVENT)
+    for row in rows:
+        assert row["event_id"] == "abc123"
+        assert row["portal_run_id"] == "20250416abcdef01"
+        assert row["library_id"] == "L2401538"
+        assert row["record_source"] == "orcabus.variantmonitoring:VariantMonitoringResult"
+
+
+def test_parse_event_site_fields_correctly_mapped():
+    rows = vm_event_handler.parse_event(SAMPLE_EVENT)
+    assert rows[0]["chrom"] == "chr1"
+    assert rows[0]["pos"] == 100000
+    assert rows[0]["af"] == pytest.approx(0.489)
+    assert rows[0]["variant_emitted"] is True
+    assert rows[1]["chrom"] == "chr7"
+    assert rows[1]["variant_emitted"] is False
+
+
+def test_parse_event_typed_values_not_cast_to_string():
+    rows = vm_event_handler.parse_event(SAMPLE_EVENT)
+    assert isinstance(rows[0]["pos"], int)
+    assert isinstance(rows[0]["af"], float)
+    assert isinstance(rows[0]["variant_emitted"], bool)
+
+
+def test_parse_event_empty_monitoring_sites_returns_no_rows():
     event = {**SAMPLE_EVENT, "detail": {**SAMPLE_EVENT["detail"], "monitoringSites": []}}
-    data = vm_event_handler.parse_event(event)
-    assert json.loads(data["monitoring_sites"]) == []
+    rows = vm_event_handler.parse_event(event)
+    assert rows == []
 
 
 def test_parse_event_wrong_detail_type():
@@ -100,15 +101,3 @@ def test_parse_event_wrong_source():
     event = {**SAMPLE_EVENT, "source": "orcabus.other"}
     with pytest.raises(ValueError, match="Invalid event source"):
         vm_event_handler.parse_event(event)
-
-
-def test_parse_event_missing_optional_fields():
-    detail = {
-        "id": "minimalid",
-        "version": "0.1.0",
-    }
-    event = {**SAMPLE_EVENT, "detail": detail}
-    data = vm_event_handler.parse_event(event)
-    assert data["orcabus_id"] == "minimalid"
-    assert data["portal_run_id"] == ""
-    assert data["monitoring_sites"] == "[]"

--- a/infra/service-event-ingestion/lambda/vm_event_handler/vm_event_handler.py
+++ b/infra/service-event-ingestion/lambda/vm_event_handler/vm_event_handler.py
@@ -1,14 +1,11 @@
 import os
-import json
 import datetime
 import boto3
 import psycopg2
 from psycopg2.extras import RealDictCursor
-from os.path import join
 import utils
 
 
-# Get the secret name from environment variables
 DB_SECRET_NAME = os.environ["DB_SECRET_NAME"]
 
 DB_SCHEMA = "psa"
@@ -18,10 +15,11 @@ DETAIL_TYPE = "VariantMonitoringResult"
 EVENT_SOURCE = "orcabus.variantmonitoring"
 RECORD_SOURCE = f"{EVENT_SOURCE}:{DETAIL_TYPE}"
 
-# Prevent inserts of the same event record multiple times
-SQL_INSERT = f"INSERT INTO {TABLE} (%s) SELECT %s WHERE NOT EXISTS (SELECT 1 FROM {TABLE} WHERE event_id = %s);"
+SQL_INSERT = (
+    f"INSERT INTO {TABLE} ({{columns}}) VALUES ({{placeholders}}) "
+    f"ON CONFLICT (portal_run_id, chrom, pos, ref, alt) DO NOTHING"
+)
 
-# DB connection
 session = boto3.session.Session()
 secretsmanager_client = boto3.client("secretsmanager")
 DB_CREDENTIALS = utils.get_secret(DB_SECRET_NAME, secretsmanager_client)
@@ -32,13 +30,12 @@ def handler(event, context):
     print("Lambda function invoked!")
     print(f"Event: {event}")
     try:
-        data = parse_event(event)
-        utils.push_to_db(DB_CONNECTION, SQL_INSERT, data)
+        rows = parse_event(event)
+        for row in rows:
+            _insert_row(DB_CONNECTION, row)
 
         print("Returning results.")
-        return {
-            'statusCode': 200,
-        }
+        return {'statusCode': 200}
 
     except Exception as e:
         print(f"An error occurred: {e}")
@@ -91,7 +88,6 @@ def parse_event(event):
     detail_type = event.get('detail-type')
     event_source = event.get('source')
 
-    # make sure we have an expected event type
     if detail_type != DETAIL_TYPE:
         raise ValueError(f"Invalid event type. Expected '{DETAIL_TYPE}' but got '{detail_type}'")
     if event_source != EVENT_SOURCE:
@@ -101,41 +97,43 @@ def parse_event(event):
     event_time = event.get('time')
     detail = event.get('detail')
 
-    data = {
+    base = {
         "event_id": event_id,
         "event_time": event_time,
-        "orcabus_id": str(detail.get('id', "")),
-        "schema_version": str(detail.get('version', "")),
-        "timestamp": str(detail.get('timestamp', "")),
         "portal_run_id": str(detail.get('portalRunId', "")),
-        "workflow_run_orcabus_id": str(detail.get('workflowRunOrcabusId', "")),
-        "workflow_name": str(detail.get('workflowName', "")),
-        "workflow_version": str(detail.get('workflowVersion', "")),
         "library_id": str(detail.get('libraryId', "")),
-        "library_orcabus_id": str(detail.get('libraryOrcabusId', "")),
-        "subject_id": str(detail.get('subjectId', "")),
-        "individual_id": str(detail.get('individualId', "")),
-        "giab_id": str(detail.get('giabId', "")),
-        "analysis_name": str(detail.get('analysisName', "")),
-        "output_uri": str(detail.get('outputUri', "")),
-        "monitoring_sites": json.dumps(detail.get('monitoringSites', [])),
         "load_datetime": datetime.datetime.now().isoformat(),
         "record_source": RECORD_SOURCE,
     }
-    print(f"Extracted data: {data}")
 
-    return data
+    sites = detail.get('monitoringSites', [])
+    if not sites:
+        print("Warning: monitoringSites is empty, skipping insert.")
+        return []
+
+    rows = []
+    for site in sites:
+        rows.append({
+            **base,
+            "chrom": site.get('chrom'),
+            "pos": site.get('pos'),
+            "ref": site.get('ref'),
+            "alt": site.get('alt'),
+            "dp": site.get('dp'),
+            "af": site.get('af'),
+            "filter_status": site.get('filter_status'),
+            "variant_emitted": site.get('variant_emitted'),
+        })
+
+    print(f"Extracted {len(rows)} site rows")
+    return rows
 
 
-def test_case():
-    # Execute example query
-    print("Executing query...")
-    with DB_CONNECTION:
-        with DB_CONNECTION.cursor(cursor_factory=RealDictCursor) as cur:
-            cur.execute(f"SELECT * FROM {TABLE_NAME} LIMIT 5")
-            results = cur.fetchall()
-
-    # Convert results to JSON-serializable format
-    print("Query executed successfully!")
-    results_list = [dict(row) for row in results]
-    print(f"Results: {results_list}")
+def _insert_row(conn, data):
+    columns = ", ".join(data.keys())
+    placeholders = ", ".join(["%s"] * len(data))
+    sql = SQL_INSERT.format(columns=columns, placeholders=placeholders)
+    with conn:
+        with conn.cursor() as cur:
+            print(f"SQL: {cur.mogrify(sql, list(data.values()))}")
+            cur.execute(sql, list(data.values()))

--- a/infra/service-event-ingestion/lambda/vm_event_handler/vm_event_handler.py
+++ b/infra/service-event-ingestion/lambda/vm_event_handler/vm_event_handler.py
@@ -1,0 +1,141 @@
+import os
+import json
+import datetime
+import boto3
+import psycopg2
+from psycopg2.extras import RealDictCursor
+from os.path import join
+import utils
+
+
+# Get the secret name from environment variables
+DB_SECRET_NAME = os.environ["DB_SECRET_NAME"]
+
+DB_SCHEMA = "psa"
+TABLE_NAME = "event__variant_monitoring_result"
+TABLE = f"{DB_SCHEMA}.{TABLE_NAME}"
+DETAIL_TYPE = "VariantMonitoringResult"
+EVENT_SOURCE = "orcabus.variantmonitoring"
+RECORD_SOURCE = f"{EVENT_SOURCE}:{DETAIL_TYPE}"
+
+# Prevent inserts of the same event record multiple times
+SQL_INSERT = f"INSERT INTO {TABLE} (%s) SELECT %s WHERE NOT EXISTS (SELECT 1 FROM {TABLE} WHERE event_id = %s);"
+
+# DB connection
+session = boto3.session.Session()
+secretsmanager_client = boto3.client("secretsmanager")
+DB_CREDENTIALS = utils.get_secret(DB_SECRET_NAME, secretsmanager_client)
+DB_CONNECTION = utils.get_db_connection(DB_CREDENTIALS)
+
+
+def handler(event, context):
+    print("Lambda function invoked!")
+    print(f"Event: {event}")
+    try:
+        data = parse_event(event)
+        utils.push_to_db(DB_CONNECTION, SQL_INSERT, data)
+
+        print("Returning results.")
+        return {
+            'statusCode': 200,
+        }
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
+        raise e
+
+
+def parse_event(event):
+    """
+    Example VariantMonitoringResult event:
+    {
+        "version": "0",
+        "id": "abc123",
+        "detail-type": "VariantMonitoringResult",
+        "source": "orcabus.variantmonitoring",
+        "account": "472057503814",
+        "time": "2025-04-16T10:00:00Z",
+        "region": "ap-southeast-2",
+        "resources": [],
+        "detail": {
+            "id": "d41d8cd98f00b204e9800998ecf8427e",
+            "version": "0.1.0",
+            "timestamp": "2025-04-16T10:00:00+00:00",
+            "portalRunId": "20250416abcdef01",
+            "workflowRunOrcabusId": "wfr.01JXXXXX",
+            "workflowName": "dragen-wgts-dna",
+            "workflowVersion": "4.3.6",
+            "libraryId": "L2401538",
+            "libraryOrcabusId": "lib.01JXXXXX",
+            "subjectId": "SBJ00001",
+            "individualId": "NA12878",
+            "giabId": "HG001",
+            "analysisName": "umccr--automated--dragen-wgts-dna--4-3-6--20250416abcdef01",
+            "outputUri": "s3://pipeline-dev-cache-xxx/byob-icav2/.../dragen-wgts-dna/20250416abcdef01/",
+            "monitoringSites": [
+                {
+                    "chrom": "chr1",
+                    "pos": 100000,
+                    "ref": "A",
+                    "alt": "T",
+                    "dp": 45,
+                    "af": 0.489,
+                    "filter_status": "PASS",
+                    "variant_emitted": true
+                }
+            ]
+        }
+    }
+    """
+    print("Parsing event...")
+    detail_type = event.get('detail-type')
+    event_source = event.get('source')
+
+    # make sure we have an expected event type
+    if detail_type != DETAIL_TYPE:
+        raise ValueError(f"Invalid event type. Expected '{DETAIL_TYPE}' but got '{detail_type}'")
+    if event_source != EVENT_SOURCE:
+        raise ValueError(f"Invalid event source. Expected '{EVENT_SOURCE}' but got '{event_source}'")
+
+    event_id = event.get('id')
+    event_time = event.get('time')
+    detail = event.get('detail')
+
+    data = {
+        "event_id": event_id,
+        "event_time": event_time,
+        "orcabus_id": str(detail.get('id', "")),
+        "schema_version": str(detail.get('version', "")),
+        "timestamp": str(detail.get('timestamp', "")),
+        "portal_run_id": str(detail.get('portalRunId', "")),
+        "workflow_run_orcabus_id": str(detail.get('workflowRunOrcabusId', "")),
+        "workflow_name": str(detail.get('workflowName', "")),
+        "workflow_version": str(detail.get('workflowVersion', "")),
+        "library_id": str(detail.get('libraryId', "")),
+        "library_orcabus_id": str(detail.get('libraryOrcabusId', "")),
+        "subject_id": str(detail.get('subjectId', "")),
+        "individual_id": str(detail.get('individualId', "")),
+        "giab_id": str(detail.get('giabId', "")),
+        "analysis_name": str(detail.get('analysisName', "")),
+        "output_uri": str(detail.get('outputUri', "")),
+        "monitoring_sites": json.dumps(detail.get('monitoringSites', [])),
+        "load_datetime": datetime.datetime.now().isoformat(),
+        "record_source": RECORD_SOURCE,
+    }
+    print(f"Extracted data: {data}")
+
+    return data
+
+
+def test_case():
+    # Execute example query
+    print("Executing query...")
+    with DB_CONNECTION:
+        with DB_CONNECTION.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(f"SELECT * FROM {TABLE_NAME} LIMIT 5")
+            results = cur.fetchall()
+
+    # Convert results to JSON-serializable format
+    print("Query executed successfully!")
+    results_list = [dict(row) for row in results]
+    print(f"Results: {results_list}")

--- a/infra/service-event-ingestion/lambda/vm_event_handler/vm_event_handler.py
+++ b/infra/service-event-ingestion/lambda/vm_event_handler/vm_event_handler.py
@@ -130,6 +130,9 @@ def parse_event(event):
 
 
 def _insert_row(conn, data):
+    # Idempotency is per site (portal_run_id, chrom, pos, ref, alt), not per event.
+    # A theoretical redelivery with different sites could merge rows from two deliveries.
+    # In practice this won't happen as the upstream service produces stable sites per portal_run_id.
     columns = ", ".join(data.keys())
     placeholders = ", ".join(["%s"] * len(data))
     sql = SQL_INSERT.format(columns=columns, placeholders=placeholders)

--- a/infra/service-event-ingestion/monitor.tf
+++ b/infra/service-event-ingestion/monitor.tf
@@ -38,6 +38,9 @@ module "lambda_error_alarms" {
     },
     "mm_lib_lambda" = {
       FunctionName = local.mm.lib_function_name
+    },
+    "vm_lambda" = {
+      FunctionName = local.vm.function_name
     }
   }
 
@@ -75,6 +78,9 @@ module "lambda_dlq_alarms" {
     },
     "mm_lib_sqs" = {
       QueueName = "${local.mm.lib_function_name}_dlq"
+    },
+    "vm_sqs" = {
+      QueueName = "${local.vm.function_name}_dlq"
     }
   }
 

--- a/infra/service-event-ingestion/vm.tf
+++ b/infra/service-event-ingestion/vm.tf
@@ -1,0 +1,35 @@
+
+################################################################################
+# Lambda for Variant Monitoring event handling
+
+locals {
+  vm = {
+    function_name = "vm_event_handler"
+  }
+}
+
+module "vm_result" {
+  source = "../common/ingest_pipe"
+
+  service_id     = "VMRES"
+  iam_path       = "/orcavault/serviceingestion/vm_result/"
+  db_secret_name = var.db_secret_name
+
+  event_pattern = {
+    detail-type = [
+      "VariantMonitoringResult"
+    ],
+    source = [
+      "orcabus.variantmonitoring"
+    ]
+  }
+
+  lambda_function_name     = local.vm.function_name
+  lambda_function_handler  = "${local.vm.function_name}.handler"
+  lambda_source_paths      = [
+    "lambda/${local.vm.function_name}",
+    "lambda/utils/utils.py"
+    ]
+  lambda_artefact_out_path = ".temp/lambda/${local.vm.function_name}.zip"
+  lambda_layers            = [aws_lambda_layer_version.psycopg2_layer.arn]
+}


### PR DESCRIPTION
## Summary

- Adds `event__variant_monitoring_result` PSA landing table (`dev/src/psa.sql`)
- Implements Lambda handler `vm_event_handler.py` to ingest variant monitoring events
- Wires up CloudWatch monitor and Terraform resources (`monitor.tf`, `vm.tf`)
- Adds service guide (`docs/service-guide.md`) and CHANGELOG

## Schema design

`monitoringSites` is flattened — one row per site, typed columns. Fields available from other PSA tables (`workflow_name`, `subject_id`, `giab_id`, etc.) are omitted to avoid redundancy.

Unique constraint on `(portal_run_id, chrom, pos, ref, alt)` — handles EventBridge at-least-once redelivery. Empty `monitoringSites` skips the insert.

| Column | Notes |
|---|---|
| `event_id`, `event_time` | EventBridge envelope — audit trail |
| `portal_run_id`, `library_id` | Join keys to other PSA tables |
| `chrom`, `pos`, `ref`, `alt`, `dp`, `af`, `filter_status`, `variant_emitted` | Site data — unique to this service |
| `load_datetime`, `record_source` | PSA metadata |

## Integration test plan

- [x] PSA table DDL applies cleanly — `make psa` runs without errors
- [x] Event lands correctly in PSA table — verified by `test_local.py` against local Postgres
- [x] Deploy Lambda and trigger with a real event payload
- [x] Check CloudWatch monitor fires on failures