### PR TITLE
Update sat schema. Remove unused PSA workflow cost field.

### DIFF
--- a/orcavault/models/dcl/sat_schema.yml
+++ b/orcavault/models/dcl/sat_schema.yml
@@ -666,6 +666,38 @@ models:
       - name: workflow_run_comment
         data_type: text
 
+  - name: sat_workflow_run_cost
+    config:
+      contract: { enforced: true }
+    constraints:
+      - type: primary_key
+        columns: [ workflow_run_hk, load_datetime ]
+      - type: foreign_key
+        columns: [ workflow_run_hk ]
+        to: ref('hub_workflow_run')
+        to_columns: [ workflow_run_hk ]
+    columns:
+      - name: workflow_run_hk
+        data_type: char(64)
+      - name: load_datetime
+        data_type: timestamptz
+      - name: record_source
+        data_type: varchar(255)
+      - name: hash_diff
+        data_type: char(64)
+      - name: portal_run_id
+        data_type: varchar(255)
+      - name: total_cost
+        data_type: numeric(10,2)
+      - name: compute_cost
+        data_type: numeric(10,2)
+      - name: license_cost
+        data_type: numeric(10,2)
+      - name: comment
+        data_type: text
+      - name: ica_project
+        data_type: varchar(255)
+
   - name: sat_s3object_by_run
     config:
       contract: { enforced: true }

--- a/orcavault/models/dcl/sat_schema.yml
+++ b/orcavault/models/dcl/sat_schema.yml
@@ -666,7 +666,7 @@ models:
       - name: workflow_run_comment
         data_type: text
 
-  - name: sat_workflow_run_cost
+  - name: sat_workflow_run_cost_ica
     config:
       contract: { enforced: true }
     constraints:
@@ -685,8 +685,6 @@ models:
         data_type: varchar(255)
       - name: hash_diff
         data_type: char(64)
-      - name: portal_run_id
-        data_type: varchar(255)
       - name: total_cost
         data_type: numeric(10,2)
       - name: compute_cost

--- a/orcavault/models/dcl/sat_workflow_run_cost_ica.sql
+++ b/orcavault/models/dcl/sat_workflow_run_cost_ica.sql
@@ -51,7 +51,6 @@ final as (
 
     select
         cast(workflow_run_hk as char(64)) as workflow_run_hk,
-        cast(hash_diff as char(64)) as workflow_run_sq,
         cast(load_datetime as timestamptz) as load_datetime,
         cast(record_source as varchar(255)) as record_source,
         cast(hash_diff as char(64)) as hash_diff,

--- a/orcavault/models/dcl/sat_workflow_run_cost_ica.sql
+++ b/orcavault/models/dcl/sat_workflow_run_cost_ica.sql
@@ -34,7 +34,6 @@ transformed as (
             license_cost,
             ica_project
         )::bytea), 'hex') as hash_diff,
-        portal_run_id,
         total_cost,
         compute_cost,
         license_cost,
@@ -54,7 +53,6 @@ final as (
         cast(load_datetime as timestamptz) as load_datetime,
         cast(record_source as varchar(255)) as record_source,
         cast(hash_diff as char(64)) as hash_diff,
-        cast(portal_run_id as char(16)) as portal_run_id,
         cast(total_cost as numeric(10,2)) as total_cost,
         cast(compute_cost as numeric(10,2)) as compute_cost,
         cast(license_cost as numeric(10,2)) as license_cost,

--- a/orcavault/models/mart/centre/workflow_cost.sql
+++ b/orcavault/models/mart/centre/workflow_cost.sql
@@ -14,14 +14,15 @@
 with source as (
 
     select
-        sat.portal_run_id as portal_run_id,
+        hw.portal_run_id as portal_run_id,
         sat.total_cost as total_cost,
         sat.compute_cost as compute_cost,
         sat.license_cost as license_cost,
         sat.comment as comment,
         sat.ica_project as ica_project
     from
-		{{ ref('sat_workflow_run_cost_ica') }} sat
+        {{ ref('hub_workflow_run') }} hw
+		join {{ ref('sat_workflow_run_cost_ica') }} sat on hw.workflow_run_hk = sat.workflow_run_hk
 
 ),
 


### PR DESCRIPTION
 A quick update from the workflow cost integration.
 
 - Add the table definition to the sat_schema.yml file
 - Remove unused `workflow_run_sq` field from workflow run cost satellite table