### PR TITLE
222 Data Mart table for Variant Monitoring Result

### DIFF
--- a/orcavault/models/mart/centre/_schema.yml
+++ b/orcavault/models/mart/centre/_schema.yml
@@ -28,3 +28,6 @@ models:
 
   - name: accreditation_lims
     description: Listing of the Centre genomic sequencing Accreditation LIMS metadata in flat table model
+
+  - name: variant_monitoring_result
+    description: Listing of the Centre genomic sequencing variant monitoring results per workflow run and library in flat table model

--- a/orcavault/models/mart/centre/variant_monitoring_result.sql
+++ b/orcavault/models/mart/centre/variant_monitoring_result.sql
@@ -4,8 +4,8 @@
             {'columns': ['portal_run_id'], 'type': 'btree'},
             {'columns': ['library_id'], 'type': 'btree'},
             {'columns': ['portal_run_id', 'library_id'], 'type': 'btree'},
-            {'columns': ['subject_id'], 'type': 'btree'},
-            {'columns': ['individual_id'], 'type': 'btree'},
+            {'columns': ['internal_subject_id'], 'type': 'btree'},
+            {'columns': ['external_subject_id'], 'type': 'btree'},
             {'columns': ['workflow_name'], 'type': 'btree'},
             {'columns': ['chrom'], 'type': 'btree'},
             {'columns': ['filter_status'], 'type': 'btree'},
@@ -41,17 +41,11 @@ source as (
     select
         wfl.portal_run_id as portal_run_id,
         lib.library_id as library_id,
-        int_sbj.internal_subject_id as subject_id,
-        ext_sbj.external_subject_id as individual_id,
-        case ext_sbj.external_subject_id
-            when 'NA12878' then 'HG001'
-            when 'NA24385' then 'HG002'
-            when 'NA24631' then 'HG005'
-            else null
-        end as giab_id,
+        int_sbj.internal_subject_id as internal_subject_id,
+        ext_sbj.external_subject_id as external_subject_id,
         wfr_sat.workflow_name as workflow_name,
         wfr_sat.workflow_version as workflow_version,
-        wfr_sat.workflow_run_start as workflow_run_start,
+        wfr_sat.workflow_run_start as workflow_start,
         sat.chrom as chrom,
         sat.pos as pos,
         sat.ref as ref,
@@ -78,12 +72,11 @@ final as (
     select
         cast(portal_run_id as char(16)) as portal_run_id,
         cast(library_id as varchar(255)) as library_id,
-        cast(subject_id as varchar(255)) as subject_id,
-        cast(individual_id as varchar(255)) as individual_id,
-        cast(giab_id as varchar(255)) as giab_id,
+        cast(internal_subject_id as varchar(255)) as internal_subject_id,
+        cast(external_subject_id as varchar(255)) as external_subject_id,
         cast(workflow_name as varchar(255)) as workflow_name,
         cast(workflow_version as varchar(255)) as workflow_version,
-        cast(workflow_run_start as timestamptz) as workflow_run_start,
+        cast(workflow_start as timestamptz) as workflow_start,
         cast(chrom as varchar(255)) as chrom,
         cast(pos as integer) as pos,
         cast(ref as varchar(255)) as ref,

--- a/orcavault/models/mart/centre/variant_monitoring_result.sql
+++ b/orcavault/models/mart/centre/variant_monitoring_result.sql
@@ -8,6 +8,9 @@
             {'columns': ['external_subject_id'], 'type': 'btree'},
             {'columns': ['workflow_name'], 'type': 'btree'},
             {'columns': ['chrom'], 'type': 'btree'},
+            {'columns': ['pos'], 'type': 'btree'},
+            {'columns': ['ref'], 'type': 'btree'},
+            {'columns': ['alt'], 'type': 'btree'},
             {'columns': ['filter_status'], 'type': 'btree'},
             {'columns': ['variant_emitted'], 'type': 'btree'},
         ]

--- a/orcavault/models/mart/centre/variant_monitoring_result.sql
+++ b/orcavault/models/mart/centre/variant_monitoring_result.sql
@@ -1,0 +1,101 @@
+{{
+    config(
+        indexes=[
+            {'columns': ['portal_run_id'], 'type': 'btree'},
+            {'columns': ['library_id'], 'type': 'btree'},
+            {'columns': ['portal_run_id', 'library_id'], 'type': 'btree'},
+            {'columns': ['subject_id'], 'type': 'btree'},
+            {'columns': ['individual_id'], 'type': 'btree'},
+            {'columns': ['workflow_name'], 'type': 'btree'},
+            {'columns': ['chrom'], 'type': 'btree'},
+            {'columns': ['filter_status'], 'type': 'btree'},
+            {'columns': ['variant_emitted'], 'type': 'btree'},
+        ]
+    )
+}}
+
+with effsat_library_internal_subject as (
+
+    select
+        lnk.*
+    from {{ ref('link_library_internal_subject') }} lnk
+        join {{ ref('effsat_library_internal_subject') }} effsat on effsat.library_internal_subject_hk = lnk.library_internal_subject_hk
+    where
+        effsat.is_current = 1
+
+),
+
+effsat_library_external_subject as (
+
+    select
+        lnk.*
+    from {{ ref('link_library_external_subject') }} lnk
+        join {{ ref('effsat_library_external_subject') }} effsat on effsat.library_external_subject_hk = lnk.library_external_subject_hk
+    where
+        effsat.is_current = 1
+
+),
+
+source as (
+
+    select
+        wfl.portal_run_id as portal_run_id,
+        lib.library_id as library_id,
+        int_sbj.internal_subject_id as subject_id,
+        ext_sbj.external_subject_id as individual_id,
+        case ext_sbj.external_subject_id
+            when 'NA12878' then 'HG001'
+            when 'NA24385' then 'HG002'
+            when 'NA24631' then 'HG005'
+            else null
+        end as giab_id,
+        wfr_sat.workflow_name as workflow_name,
+        wfr_sat.workflow_version as workflow_version,
+        wfr_sat.workflow_run_start as workflow_run_start,
+        sat.chrom as chrom,
+        sat.pos as pos,
+        sat.ref as ref,
+        sat.alt as alt,
+        sat.dp as dp,
+        sat.af as af,
+        sat.filter_status as filter_status,
+        sat.variant_emitted as variant_emitted
+    from
+        {{ ref('hub_workflow_run') }} wfl
+            join {{ ref('link_library_workflow_run') }} lnk on lnk.workflow_run_hk = wfl.workflow_run_hk
+            join {{ ref('hub_library') }} lib on lnk.library_hk = lib.library_hk
+            join {{ ref('sat_variant_monitoring_result') }} sat on lnk.library_workflow_run_hk = sat.library_workflow_run_hk
+            left join {{ ref('sat_workflow_run') }} wfr_sat on wfr_sat.workflow_run_hk = wfl.workflow_run_hk
+            left join effsat_library_internal_subject eff_int on eff_int.library_hk = lib.library_hk
+            left join {{ ref('hub_internal_subject') }} int_sbj on int_sbj.internal_subject_hk = eff_int.internal_subject_hk
+            left join effsat_library_external_subject eff_ext on eff_ext.library_hk = lib.library_hk
+            left join {{ ref('hub_external_subject') }} ext_sbj on ext_sbj.external_subject_hk = eff_ext.external_subject_hk
+
+),
+
+final as (
+
+    select
+        cast(portal_run_id as char(16)) as portal_run_id,
+        cast(library_id as varchar(255)) as library_id,
+        cast(subject_id as varchar(255)) as subject_id,
+        cast(individual_id as varchar(255)) as individual_id,
+        cast(giab_id as varchar(255)) as giab_id,
+        cast(workflow_name as varchar(255)) as workflow_name,
+        cast(workflow_version as varchar(255)) as workflow_version,
+        cast(workflow_run_start as timestamptz) as workflow_run_start,
+        cast(chrom as varchar(255)) as chrom,
+        cast(pos as integer) as pos,
+        cast(ref as varchar(255)) as ref,
+        cast(alt as varchar(255)) as alt,
+        cast(dp as integer) as dp,
+        cast(af as double precision) as af,
+        cast(filter_status as varchar(255)) as filter_status,
+        cast(variant_emitted as boolean) as variant_emitted
+    from
+        source
+    order by portal_run_id desc nulls last, library_id desc
+
+)
+
+select * from final

--- a/orcavault/seeds/dictionary/dictionary__data_mart_catalog.csv
+++ b/orcavault/seeds/dictionary/dictionary__data_mart_catalog.csv
@@ -11,6 +11,7 @@ external_lims,Listing of the Externally sequenced LIMS metadata in flat table mo
 em_library_services,Listing of the Centre sequenced libray availability in OrcaBus services,STABLE
 em_library_aliases,Listing of the Centre sequenced libray aliases with run comments by the lab team,STABLE
 em_library_dns,Listing of the Centre do not sequence (dns) libray with run comments by the lab team,STABLE
+variant_monitoring_result,Listing of the Centre genomic sequencing variant monitoring results per workflow run and library in flat table model,DEMO
 curation_lims,Listing of the Centre Curation Team LIMS metadata in flat table model,DEMO
 grimmond_lims,Listing of Grimmond Research Group LIMS metadata in flat table model,DEMO
 dawson_lims,Listing of Dawson Research Group LIMS metadata in flat table model,DEMO


### PR DESCRIPTION
## Summary

- #222
- https://github.com/umccr/orcahouse-doc/pull/new/222-mart-variant-monitoring-result

## Changes

- `orcavault/models/mart/centre/variant_monitoring_result.sql` — new OBT-style mart table
- `orcavault/models/mart/centre/_schema.yml` — model registered
- `orcavault/seeds/dictionary/dictionary__data_mart_catalog.csv` — catalogued as `DEMO`

## Design

Joins DCL layer to produce a wide flat table consumable by `service-variant-monitoring-report`:

| Column | Source |
|---|---|
| `portal_run_id`, `library_id` | `hub_workflow_run`, `hub_library` |
| `internal_subject_id` | `hub_internal_subject` via effsat |
| `external_subject_id` | `hub_external_subject` via effsat |
| `workflow_name`, `workflow_version`, `workflow_start` | `sat_workflow_run` |
| `chrom`, `pos`, `ref`, `alt`, `dp`, `af`, `filter_status`, `variant_emitted` | `sat_variant_monitoring_result` |

## Test

```sql
select * from mart.variant_monitoring_result;
```