### PR TITLE
Fixed ETL script to drop request_id column

### DIFF
--- a/infra/glue/workspace/spreadsheet_library_tracking_metadata/spreadsheet_library_tracking_metadata.py
+++ b/infra/glue/workspace/spreadsheet_library_tracking_metadata/spreadsheet_library_tracking_metadata.py
@@ -93,6 +93,10 @@ def transform():
             case '2026':
                 df = df.with_columns(pl.lit('').alias('zStudy'))
 
+                # FIXME Drop the request_id column from 2026 sheet for now
+                #  See https://github.com/umccr/orcahouse/issues/230
+                df = df.drop('request_id')
+
         # globally rename
         df = df.rename({
             'Coverage (X)': 'Coverage',


### PR DESCRIPTION
* This is temporary fix to drop the request_id column from the
  incoming Lab Library Tracking spreadsheet data.
