### PR TITLE
Implemented data warehouse Glue Crawler to Catalogue orcabus-db CDC datalake

### DIFF
--- a/infra/glue-crawler/orcabus-db/.terraform.lock.hcl
+++ b/infra/glue-crawler/orcabus-db/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.43.0"
+  constraints = "6.43.0"
+  hashes = [
+    "h1:/A3VpeGOhvutRSlGACfUKeBMFZa3CTSLIqvT+XH0364=",
+    "zh:0fe91026ce8c5178781de6773531dcfcf5280ee139059dc5a0c046f1532cf389",
+    "zh:114001f94c38db8702210eda643ec627fa1929a88f774e17db30bc172df6759e",
+    "zh:1fc668d57c7edd81c06f5705b03517393444fe4988a68a3fd90b5b21fed64a55",
+    "zh:2bc0b4d5b706c3bbe7824bcf410942ee631d3423c23f935a51129832d81e1e17",
+    "zh:3f27e2befae3393df2ba423abba7f64c774d8aa6e0de20d00b35d7cca6f47d65",
+    "zh:410bfc19e1f38b7caabc5e1b9cd2de196bdcaa02c840372be26734775ee0214c",
+    "zh:417181a86499386ffbf4d023b9c5219a0d322751513806e977f146f170f0aebc",
+    "zh:6764d31dbae9656b698a3b9d4a44e4267210375ff9bec3e8716bac4450a06f0d",
+    "zh:86401475746c94b12e90b065b76a77c635a84d9cbfc57eace65131c780bd34c6",
+    "zh:98388ac853abbcb18fdf578c18203f485479610d28329c21deefc573976e4b1d",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:afb84c77c569e9979b8287cde33543cff992ca17e62ebe3f2b4a8e69884dbdc5",
+    "zh:c54c64dba350e6856fb8f2813b81d20286a532b02bad5f67da35135c02594407",
+    "zh:d1a46adf1c8f5bf42a1886b06fd25d86981236c933165f0fbc07e4330b77d8d1",
+    "zh:e719e227a676588cdaa5a3e7e3e6b10da26830a566730e8bce2127eec1780f40",
+  ]
+}

--- a/infra/glue-crawler/orcabus-db/README.md
+++ b/infra/glue-crawler/orcabus-db/README.md
@@ -1,0 +1,11 @@
+# Glue Clawer for orcabus-db datalake
+
+This stack provisions a Glue Clawer for the orcabus-db datalake created by the [DMS CDC stack](../../dms/orcabus-db).
+
+```
+export AWS_PROFILE=unimelb-warehouse-prod-admin
+
+terraform init
+terraform plan
+terraform apply
+```

--- a/infra/glue-crawler/orcabus-db/crawler.tf
+++ b/infra/glue-crawler/orcabus-db/crawler.tf
@@ -1,0 +1,53 @@
+# The main Glue crawler
+
+resource "aws_glue_catalog_database" "this" {
+  for_each = toset(local.databases)
+
+  name        = "orcabus_${each.key}"
+  description = "Glue catalog database for ${each.key} CDC data"
+}
+
+resource "aws_glue_crawler" "this" {
+  for_each = toset(local.databases)
+
+  database_name = "orcabus_${each.key}"
+  name          = "${local.name_prefix}-crawler-${replace(each.key, "_", "-")}"
+  role          = aws_iam_role.glue_crawler.arn
+
+  configuration = jsonencode({
+    Version = 1.0
+    CrawlerOutput = {
+      Partitions = {
+        AddOrUpdateBehavior = "InheritFromTable"
+      }
+      Tables = {
+        AddOrUpdateBehavior = "MergeNewColumns" # Add new columns on schema evolution
+      }
+    }
+    Grouping = {
+      TableGroupingPolicy     = "CombineCompatibleSchemas"
+      TableLevelConfiguration = 7 # folder depth — database/schema/table
+    }
+  })
+
+  schema_change_policy {
+    delete_behavior = "LOG" # Log schema deletions — do not drop tables
+    update_behavior = "LOG" # Log update schema changes
+  }
+
+  lineage_configuration {
+    crawler_lineage_settings = "DISABLE"
+  }
+
+  recrawl_policy {
+    recrawl_behavior = "CRAWL_NEW_FOLDERS_ONLY" # Only crawl new partitions
+  }
+
+  s3_target {
+    path       = "s3://${data.aws_s3_bucket.lz.bucket}/orcabus/v1/cdc/${each.key}/"
+    exclusions = ["*.{tsv,csv,avro,json,orc}"]
+  }
+
+  # Runs at the top of every hour, every day in UTC
+  schedule = "cron(0 * * * ? *)"
+}

--- a/infra/glue-crawler/orcabus-db/iam.tf
+++ b/infra/glue-crawler/orcabus-db/iam.tf
@@ -1,0 +1,42 @@
+data "aws_iam_policy_document" "glue_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type = "Service"
+      identifiers = [
+        "glue.amazonaws.com"
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "glue_crawler" {
+  name               = "${local.name_prefix}-glue-crawler-role"
+  assume_role_policy = data.aws_iam_policy_document.glue_assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "glue_service" {
+  role       = aws_iam_role.glue_crawler.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
+}
+
+data "aws_iam_policy_document" "glue_crawler" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:ListBucket"
+    ]
+    resources = [
+      data.aws_s3_bucket.lz.arn,
+      "${data.aws_s3_bucket.lz.arn}/*"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "glue_crawler" {
+  name   = "${local.name_prefix}-glue-crawler-policy"
+  role   = aws_iam_role.glue_crawler.id
+  policy = data.aws_iam_policy_document.glue_crawler.json
+}

--- a/infra/glue-crawler/orcabus-db/main.tf
+++ b/infra/glue-crawler/orcabus-db/main.tf
@@ -1,0 +1,42 @@
+terraform {
+  required_version = ">= 1.15.0"
+
+  backend "s3" {
+    bucket       = "terraform-states-ccfgcm"
+    key          = "115253169271/orcahouse/glue-crawler/orcabus-db/terraform.tfstate"
+    region       = "ap-southeast-2"
+    use_lockfile = true
+    encrypt      = true
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "6.43.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "ap-southeast-2"
+
+  default_tags {
+    tags = {
+      "umccr-org:Product" = "OrcaHouse"
+      "umccr-org:Creator" = "Terraform"
+      "umccr-org:Service" = "OrcaHouse"
+      "umccr-org:Source"  = "https://github.com/umccr/orcahouse"
+    }
+  }
+}
+
+# ---
+
+locals {
+  name_prefix = "orcabus-db"
+  databases   = ["workflow_manager", "sequence_run_manager", "metadata_manager", "filemanager"]
+}
+
+data "aws_s3_bucket" "lz" {
+  bucket = "orcahouse-landing-zone-115253169271-ap-southeast-2-an"
+}


### PR DESCRIPTION
* This stack implements the Data Catalogue solution for orcabus-db CDC datalake
  by using Glue Crawler. Chiefly, leveraging the crawler capability to infer
  parquet table structure, column inference and "schema evolution".
* The data catalogue can be readily queried by Athena and Redshift.

Prior Art:

This is the Same or, based on prior work POC datalake with dracarys tidied parquet files.
https://github.com/umccr/infrastructure/tree/7f5062e/terraform/stacks/umccr_datalake
