### PR TITLE
Updated DCL WorkflowHub source from mdm__workflow_run

### DIFF
--- a/orcavault/models/dcl/hub_workflow_run.sql
+++ b/orcavault/models/dcl/hub_workflow_run.sql
@@ -45,6 +45,10 @@ combined as (
     select distinct portal_run_id from source1
     union
     select distinct portal_run_id from source2
+    union
+    select distinct base_portal_run_id from {{ ref('mdm__workflow_run') }}
+    union
+    select distinct alias_portal_run_id from {{ ref('mdm__workflow_run') }}
 
 ),
 


### PR DESCRIPTION
* This allows adding some master data records from the mdm__workflow_run
  to WorkflowRunHub. As if they were curated elsewhere for re-entry into the
  warehouse for DCL (Data Consolidation Layer) purpose.
