### PR TITLE
Migrate API Terraform backend locking to S3 lockfile

### DIFF
--- a/infra/api/lambda-server/package.json
+++ b/infra/api/lambda-server/package.json
@@ -13,7 +13,7 @@
   "keywords": [],
   "author": "",
   "license": "MIT",
-  "packageManager": "pnpm@11.12.0+sha512.820a6fbd0d9f04c226638002aead1e45340a9139dd5dc077c1d83ef44aa2481c8eb6637b4c9aa696a3c7e35ba818e49cf27213e5f2b91138d09b7a3e26e898ba",
+  "packageManager": "pnpm@11.13.1+sha512.b2fc7683b8a6525414e7d13e1ba28caaddde96bf66ec540bfaeb7e702b81f3e0be4d1f295edf7f9fe0396740a8dce4509c582ddf79891f4543fea32d37645f25",
   "dependencies": {
     "@dataplan/json": "1.0.1",
     "@dataplan/pg": "1.1.0",

--- a/infra/api/main.tf
+++ b/infra/api/main.tf
@@ -5,7 +5,7 @@ terraform {
     bucket         = "umccr-terraform-states"
     key            = "orcahouse/api/terraform.tfstate"
     region         = "ap-southeast-2"
-    dynamodb_table = "terraform-state-lock"
+    use_lockfile   = true
   }
 
   required_providers {


### PR DESCRIPTION

## Summary:
This PR updates the API Terraform backend config to use S3 native lockfile-based state locking instead of the deprecated DynamoDB lock table parameter.

## Changes:

Updated backend locking in `main.tf`. Replaced `dynamodb_table = "terraform-state-lock"` with `use_lockfile = true`.

## Why:
Terraform now warns that `dynamodb_table` is deprecated for the S3 backend. This change aligns the API module with current Terraform backend locking guidance and with newer modules in this repo that already use `use_lockfile`.
References from [hashicorp develop doc](https://developer.hashicorp.com/terraform/language/backend/s3#state-locking)
<img width="395" height="123" alt="image" src="https://github.com/user-attachments/assets/173566e6-84a0-4eb7-9427-09edf471d9e3" />

> Also the packageManager  upgraded from pnpm 11.12.0 to 11.13.1 in package.json.
