### PR TITLE
Improved DMS CDC parquet datalake partition format SLASH

### DIFF
--- a/infra/dms/orcabus-db/dms.tf
+++ b/infra/dms/orcabus-db/dms.tf
@@ -62,7 +62,7 @@ resource "aws_dms_s3_endpoint" "target" {
   # Partition by date
   date_partition_enabled   = true
   date_partition_sequence  = "YYYYMMDD"
-  date_partition_delimiter = "DASH"
+  date_partition_delimiter = "SLASH"
 
   # CDC timestamp column
   timestamp_column_name = "_dms_cdc_timestamp"


### PR DESCRIPTION
* It is found that the CDC parquet data sink partition is better fit with
  SLASH format for the warehouse pre-stage immutable-datalake use case.
