### PR TITLE
feat: add mart.vcf which contains centre vcfs similar to mart.bam

### DIFF
--- a/orcavault/macros/grant_select.sql
+++ b/orcavault/macros/grant_select.sql
@@ -9,6 +9,7 @@
     CREATE VIEW public.fastq as SELECT * FROM mart.fastq;
     CREATE VIEW public.fastq_history as SELECT * FROM mart.fastq_history;
     CREATE VIEW public.bam as SELECT * FROM mart.bam;
+    CREATE VIEW public.vcf as SELECT * FROM mart.vcf;
     CREATE VIEW public.workflow as SELECT * FROM mart.workflow;
     GRANT USAGE ON SCHEMA public TO {{ role }};
     GRANT SELECT ON ALL tables IN SCHEMA public TO {{ role }};

--- a/orcavault/models/mart/centre/_schema.yml
+++ b/orcavault/models/mart/centre/_schema.yml
@@ -17,6 +17,9 @@ models:
   - name: bam
     description: Listing of the Centre genomic sequencing aligned read level file BAM and BAI S3 locations in flat table model
 
+  - name: vcf
+    description: Listing of the Centre genomic sequencing variant call file VCF and VCF.TBI S3 locations in flat table model
+
   - name: workflow
     description: Listing of the Centre genomic sequencing analysis workflow run details in flat table model
 

--- a/orcavault/models/mart/centre/vcf.sql
+++ b/orcavault/models/mart/centre/vcf.sql
@@ -1,0 +1,70 @@
+{{
+    config(
+        indexes=[
+            {'columns': ['portal_run_id'], 'type': 'btree'},
+            {'columns': ['cohort_id'], 'type': 'btree'},
+            {'columns': ['library_id'], 'type': 'btree'},
+            {'columns': ['portal_run_id', 'library_id'], 'type': 'btree'},
+            {'columns': ['bucket'], 'type': 'btree'},
+            {'columns': ['key'], 'type': 'btree'},
+            {'columns': ['filename'], 'type': 'btree'},
+            {'columns': ['format'], 'type': 'btree'},
+            {'columns': ['size'], 'type': 'btree'},
+            {'columns': ['storage_class'], 'type': 'btree'},
+            {'columns': ['last_modified_date'], 'type': 'btree'},
+        ]
+    )
+}}
+
+with transformed as (
+
+    select
+        {{ extract_portal_run_id("hub.key") }} as portal_run_id,
+        {{ extract_cohort_id("hub.key") }} as cohort_id,
+        hub.bucket as bucket,
+        hub.key as "key",
+        sat.library_id as library_id,
+        sat.filename as filename,
+        case
+            when sat.ext2 = 'vcf' and sat.ext1 = 'gz' then 'vcf.gz'
+            when sat.ext3 = 'vcf' and sat.ext2 = 'gz' and sat.ext1 = 'tbi' then 'vcf.gz.tbi'
+        end as format,
+        cur.size as "size",
+        cur.storage_class as storage_class,
+        cur.e_tag as e_tag,
+        cur.last_modified_date as last_modified_date
+    from {{ ref('hub_s3object') }} hub
+        join {{ ref('sat_s3object_by_library') }} sat on sat.s3object_hk = hub.s3object_hk
+        join {{ ref('sat_s3object_current') }} cur on cur.s3object_hk = hub.s3object_hk
+    where
+        (
+            (sat.ext2 = 'vcf' and sat.ext1 = 'gz')
+            or (sat.ext3 = 'vcf' and sat.ext2 = 'gz' and sat.ext1 = 'tbi')
+        )
+        and cur.is_current = 1
+        and cur.is_deleted = 0
+        and cur.version_active
+
+),
+
+final as (
+
+    select
+        cast(portal_run_id as char(16)) as portal_run_id,
+        cast(cohort_id as varchar(255)) as cohort_id,
+        cast(bucket as varchar(255)) as bucket,
+        cast("key" as text) as "key",
+        cast(library_id as varchar(255)) as library_id,
+        cast(filename as text) as filename,
+        cast(format as varchar(255)) as format,
+        cast("size" as bigint) as "size",
+        cast(storage_class as varchar(255)) as storage_class,
+        cast(e_tag as varchar(255)) as e_tag,
+        cast(last_modified_date as timestamptz) as last_modified_date
+    from
+        transformed
+    order by portal_run_id desc nulls last, library_id desc
+
+)
+
+select * from final

--- a/orcavault/seeds/dictionary/dictionary__data_mart_catalog.csv
+++ b/orcavault/seeds/dictionary/dictionary__data_mart_catalog.csv
@@ -3,6 +3,7 @@ lims,Listing of the Centre genomic sequencing LIMS metadata in flat table model,
 fastq,Listing of the Centre genomic sequencing unaligned read level file FASTQ S3 locations in flat table model,STABLE
 fastq_history,Listing of the Centre genomic sequencing unaligned read level file FASTQ S3 historical locations,STABLE
 bam,Listing of the Centre genomic sequencing aligned read level file BAM and BAI S3 locations in flat table model,STABLE
+vcf,Listing of the Centre genomic sequencing variant call file VCF and VCF.TBI S3 locations in flat table model,DEMO
 workflow,Listing of the Centre genomic sequencing analysis workflow run details in flat table model,STABLE
 workflow_cost,Listing of the Centre genomic sequencing analysis workflow run costs in flat table model,DEMO
 workflow_cost_report,Listing of the Centre genomic sequencing analysis workflow run costs in flat table model based on the ICA usage report,DEMO


### PR DESCRIPTION
Closes https://github.com/umccr/orcahouse-user-stories/issues/14

### Changes
* Add vcf mart to centre marts, following similar structure to bam mart.
    * Only vcf.gz and vcf.gz.tbi, as I don't think we have any plain VCFs. 
* Also added to grant_select.sql, and a dbt data test. Let me know if you don't want these, as it's slightly outside of the existing pattern, so I'm happy to remove it. 